### PR TITLE
Fix subscription id displayed instead of transaction

### DIFF
--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -296,7 +296,6 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 			if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
 				update_post_meta( $order_id, '_ecurring_subscription_id', $response['data']['id'] );
-				update_post_meta( $order_id, '_transaction_id', $response['data']['id'] );
 
 				$confirmation_page = $response['data']['attributes']['confirmation_page'];
 				$subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,5 +8,9 @@ if (!file_exists($vendor . 'autoload.php')) {
 
 require_once __DIR__ . '/stubs.php';
 require_once $vendor . 'autoload.php';
+require_once "{$projectDir}/includes/ecurring/wc/autoload.php";
 
 unset($vendor, $projectDir);
+
+// Register autoloader
+eCurring_WC_Autoload::register();


### PR DESCRIPTION
Implements [ECUR-29](https://inpsyde.atlassian.net/browse/ECUR-29).

Also fixes notices on the order edit page and tests bootstrap.