### PR TITLE
Prevent multiple subscriptions for the same order

### DIFF
--- a/includes/ecurring/wc/exception/apiclientexception.php
+++ b/includes/ecurring/wc/exception/apiclientexception.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Thrown when API request problem occurred.
+ */
+class eCurring_WC_Exception_ApiClientException extends eCurring_WC_Exception{}

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -303,6 +303,8 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             if(! $subscription_exists)
             {
+                $raw_api_response = apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', null);
+
                 $response = $api->createSubscription($data);
 
                 if ( isset( $response['errors'] ) ) {
@@ -314,7 +316,12 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
                     $this->updateOrderWithSubscriptionData($response, $order);
                 }
 
-                do_action( WOOECUR_PLUGIN_ID . '_payment_created', $rawResponse, $order );
+                /**
+                 * This action was triggered here before with unparsed api response data, so we have to do the same.
+                 * We getting raw response above via filter.
+                 * It would be great idea to deprecate this action and add another one with parsed response as argument.
+                 */
+                do_action( WOOECUR_PLUGIN_ID . '_payment_created', $raw_api_response, $order );
             }
 
 			$redirect = isset( $response['error'] ) ? '' : $response['data']['attributes']['confirmation_page'] . '?accepted=true';

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -290,17 +290,18 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
 
             $subscription_id = get_post_meta('_ecurring_subscription_id', true);
+            $subscription_exists = false;
 
-            if(! $subscription_id) {
-                //todo: update existing subscription here.
+            if($subscription_id) {
+                $subscriptionData = $api->getSubscriptionById($subscription_id);
+
+                if(isset($subscriptionData['type']) && $subscriptionData['type'] === 'subscription'){
+                    $subscription_exists = true;
+                }
             }
 
-            $subscriptionData = $api->getSubscriptionById($subscription_id);
-
-            if(! isset($subscriptionData['type']) || $subscriptionData['type'] !== 'subscription')
+            if(! $subscription_exists)
             {
-                //todo: update existing subscription here.
-            } else {
                 $rawResponse = $api->createSubscription($data);
                 $response = json_decode( $rawResponse, true );
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -291,18 +291,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             $subscription_id = get_post_meta($order_id, '_ecurring_subscription_id', true);
 
-            $subscription_exists = false;
-
-            if($subscription_id) {
-                $subscription_data = $api->getSubscriptionById($subscription_id);
-
-                if(isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription'){
-                    $subscription_exists = true;
-                }
-            }
-
-            if(! $subscription_exists)
-            {
+            if(! $this->subscriptionExists($subscription_id)) {
                 $rawResponse = $api->createSubscription($data);
                 $response = json_decode( $rawResponse, true );
 
@@ -351,6 +340,27 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 		return array ( 'result' => 'failure' );
 	}
+
+    /**
+     * Check if subscription exists.
+     *
+     * @param $subscription_id
+     *
+     * @return bool
+     * @throws eCurring_WC_Exception_ApiClientException
+     */
+	protected function subscriptionExists($subscription_id)
+    {
+        if(! $subscription_id) {
+            return false;
+        }
+
+        $api = eCurring_WC_Plugin::getApiHelper();
+        $subscription_data = $api->getSubscriptionById($subscription_id);
+
+        return isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription';
+
+    }
 
 	protected function updateOrderWithSubscriptionData(array $response, WC_Order $order)
     {

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -303,9 +303,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             }
 
             if (! isset($subscription_data)) {
-                $raw_api_response = apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', null);
-
                 $subscription_data = $api->createSubscription($data);
+
+                $raw_api_response = apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', null);
 
                 $this->updateOrderWithSubscriptionData($subscription_data, $order);
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -303,8 +303,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             if(! $subscription_exists)
             {
-                $rawResponse = $api->createSubscription($data);
-                $response = json_decode( $rawResponse, true );
+                $response = $api->createSubscription($data);
 
                 if ( isset( $response['errors'] ) ) {
                     eCurring_WC_Plugin::debug( 'Creating eCurring subscription failed with error ' . print_r($response['errors'], TRUE ) );

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -295,7 +295,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 			$response = json_decode( $request, true );
 
 			if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
-				$this->updateOrderWithSubscriptionData($order_id, $response, $order);
+				$this->updateOrderWithSubscriptionData($response, $order);
 			}
 
 			if ( isset( $response['errors'] ) ) {
@@ -338,9 +338,15 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		return array ( 'result' => 'failure' );
 	}
 
-	protected function updateOrderWithSubscriptionData($order_id, array $response, WC_Order $order)
+	protected function updateOrderWithSubscriptionData(array $response, WC_Order $order)
     {
         $ecurring_subscription_id = $response['data']['id'];
+
+        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+            $order_id = $order->id;
+        } else {
+            $order_id = $order->get_id();
+        }
 
         update_post_meta( $order_id, '_ecurring_subscription_id',  $ecurring_subscription_id);
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -307,9 +307,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
                 $response = $api->createSubscription($data);
 
-                if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
-                    $this->updateOrderWithSubscriptionData($response, $order);
-                }
+                $this->updateOrderWithSubscriptionData($response, $order);
 
                 /**
                  * This action was triggered here before with unparsed api response data, so we have to do the same.

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -295,7 +295,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 			$response = json_decode( $request, true );
 
 			if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
-				$this->updateOrderWithSubscriptionData($order_id, $response);
+				$this->updateOrderWithSubscriptionData($order_id, $response, $order);
 			}
 
 			if ( isset( $response['errors'] ) ) {
@@ -338,7 +338,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		return array ( 'result' => 'failure' );
 	}
 
-	protected function updateOrderWithSubscriptionData($order_id, array $response)
+	protected function updateOrderWithSubscriptionData($order_id, array $response, WC_Order $order)
     {
         $ecurring_subscription_id = $response['data']['id'];
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -313,10 +313,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
                 if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
                     $this->updateOrderWithSubscriptionData($response, $order);
                 }
+
+                do_action( WOOECUR_PLUGIN_ID . '_payment_created', $rawResponse, $order );
             }
-
-
-			do_action( WOOECUR_PLUGIN_ID . '_payment_created', $rawResponse, $order );
 
 			$redirect = isset( $response['error'] ) ? '' : $response['data']['attributes']['confirmation_page'] . '?accepted=true';
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -291,9 +291,18 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             $subscription_id = get_post_meta($order_id, '_ecurring_subscription_id', true);
 
-            if($subscription_id) {
-                $subscription_data = $api->getSubscriptionById($subscription_id);
-            } else {
+            if ($subscription_id) {
+                try{
+                    $subscription_data = $api->getSubscriptionById($subscription_id);
+                } catch (eCurring_WC_Exception_ApiClientException $exception) {
+                    eCurring_WC_Plugin::debug(
+                        sprintf('Subscription %1$s for order %2$s not found on the remote API.', $subscription_id, $order_id),
+                        true
+                    );
+                }
+            }
+
+            if (! isset($subscription_data)) {
                 $raw_api_response = apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', null);
 
                 $subscription_data = $api->createSubscription($data);

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -291,7 +291,18 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             $subscription_id = get_post_meta($order_id, '_ecurring_subscription_id', true);
 
-            if(! $this->subscriptionExists($subscription_id)) {
+            $subscription_exists = false;
+
+            if($subscription_id) {
+                $subscription_data = $api->getSubscriptionById($subscription_id);
+
+                if(isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription'){
+                    $subscription_exists = true;
+                }
+            }
+
+            if(! $subscription_exists)
+            {
                 $rawResponse = $api->createSubscription($data);
                 $response = json_decode( $rawResponse, true );
 
@@ -340,27 +351,6 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 		return array ( 'result' => 'failure' );
 	}
-
-    /**
-     * Check if subscription exists.
-     *
-     * @param $subscription_id
-     *
-     * @return bool
-     * @throws eCurring_WC_Exception_ApiClientException
-     */
-	protected function subscriptionExists($subscription_id)
-    {
-        if(! $subscription_id) {
-            return false;
-        }
-
-        $api = eCurring_WC_Plugin::getApiHelper();
-        $subscription_data = $api->getSubscriptionById($subscription_id);
-
-        return isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription';
-
-    }
 
 	protected function updateOrderWithSubscriptionData(array $response, WC_Order $order)
     {

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -348,11 +348,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
         $subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];
         update_post_meta( $order_id, '_ecurring_subscription_link', $subscription_link );
 
-        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $ecurring_subscription_id . ' created for order ' . $order->id );
-        } else {
-            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $ecurring_subscription_id . ' created for order ' . $order->get_id() );
-        }
+        eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $ecurring_subscription_id . ' created for order ' . $order_id );
 
         $order->add_order_note( sprintf(
         /* translators: Placeholder 1: Payment method title, placeholder 2: payment ID */

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -296,9 +296,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             if($subscription_id) {
                 $subscription_data = $api->getSubscriptionById($subscription_id);
 
-                if(isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription'){
-                    $subscription_exists = true;
-                }
+                $subscription_exists = true;
             }
 
             if(! $subscription_exists)

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -504,7 +504,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		$api = eCurring_WC_Plugin::getApiHelper();
 		$eCurring_subscription_id = get_post_meta($order_id,'_ecurring_subscription_id',true);
 
-		$eCurring_subscription = $api->getSubscriptionById($eCurring_subscription_id)['data'];
+		$eCurring_subscription = json_decode($api->apiCall('GET','https://api.ecurring.com/subscriptions/'.$eCurring_subscription_id),true)['data'];
 
 		$eCurring_subscription_attr = $eCurring_subscription['attributes'];
 		$mandate_data = array(

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -338,7 +338,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		return array ( 'result' => 'failure' );
 	}
 
-	protected function updateOrderWithSubscriptionData($order_id, $response)
+	protected function updateOrderWithSubscriptionData($order_id, array $response)
     {
         $ecurring_subscription_id = $response['data']['id'];
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -488,7 +488,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		$api = eCurring_WC_Plugin::getApiHelper();
 		$eCurring_subscription_id = get_post_meta($order_id,'_ecurring_subscription_id',true);
 
-		$eCurring_subscription = json_decode($api->apiCall('GET','https://api.ecurring.com/subscriptions/'.$eCurring_subscription_id),true)['data'];
+		$eCurring_subscription = json_decode($api->getSubscriptionById($eCurring_subscription_id),true)['data'];
 
 		$eCurring_subscription_attr = $eCurring_subscription['attributes'];
 		$mandate_data = array(

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -285,14 +285,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 				)
 			);
 
-			$data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
-
-			do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
-
-			// Create eCurring subscription with customer id.
-			$request = $api->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
-
-			$response = json_decode( $request, true );
+            // Create eCurring subscription with customer id.
+			$rawResponse = $api->createSubscription($data, $order);
+            $response = json_decode( $rawResponse, true );
 
             if ( isset( $response['errors'] ) ) {
                 eCurring_WC_Plugin::debug( 'Creating eCurring subscription failed with error ' . print_r($response['errors'], TRUE ) );
@@ -303,7 +298,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 				$this->updateOrderWithSubscriptionData($response, $order);
 			}
 
-			do_action( WOOECUR_PLUGIN_ID . '_payment_created', $request, $order );
+			do_action( WOOECUR_PLUGIN_ID . '_payment_created', $rawResponse, $order );
 
 			$redirect = isset( $response['error'] ) ? '' : $response['data']['attributes']['confirmation_page'] . '?accepted=true';
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -295,26 +295,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 			$response = json_decode( $request, true );
 
 			if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
-				update_post_meta( $order_id, '_ecurring_subscription_id', $response['data']['id'] );
-				update_post_meta( $order_id, '_transaction_id', $response['data']['id'] );
-
-				$confirmation_page = $response['data']['attributes']['confirmation_page'];
-				$subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];
-				update_post_meta( $order_id, '_ecurring_subscription_link', $subscription_link );
-
-				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-					eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->id );
-				} else {
-					eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->get_id() );
-				}
-
-				$order->add_order_note( sprintf(
-				/* translators: Placeholder 1: Payment method title, placeholder 2: payment ID */
-					__( 'Manual %s payment started for subscription ID %s.', 'woo-ecurring' ),
-					$this->method_title,
-					'<a href="'.$subscription_link.'" target="_blank">'.$response['data']['id'].'</a>'
-				) );
-
+				$this->updateOrderWithSubscriptionData($order_id, $response);
 			}
 
 			if ( isset( $response['errors'] ) ) {
@@ -356,6 +337,29 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 		return array ( 'result' => 'failure' );
 	}
+
+	protected function updateOrderWithSubscriptionData($order_id, $response)
+    {
+        update_post_meta( $order_id, '_ecurring_subscription_id', $response['data']['id'] );
+        update_post_meta( $order_id, '_transaction_id', $response['data']['id'] );
+
+        $confirmation_page = $response['data']['attributes']['confirmation_page'];
+        $subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];
+        update_post_meta( $order_id, '_ecurring_subscription_link', $subscription_link );
+
+        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->id );
+        } else {
+            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->get_id() );
+        }
+
+        $order->add_order_note( sprintf(
+        /* translators: Placeholder 1: Payment method title, placeholder 2: payment ID */
+            __( 'Manual %s payment started for subscription ID %s.', 'woo-ecurring' ),
+            $this->method_title,
+            '<a href="'.$subscription_link.'" target="_blank">'.$response['data']['id'].'</a>'
+        ) );
+    }
 
     /**
      * @param WC_Order $order

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -286,7 +286,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 			);
 
             // Create eCurring subscription with customer id.
-			$rawResponse = $api->createSubscription($data, $order);
+            $data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
+            do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
+			$rawResponse = $api->createSubscription($data);
             $response = json_decode( $rawResponse, true );
 
             if ( isset( $response['errors'] ) ) {

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -296,7 +296,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             if($subscription_id) {
                 $subscriptionData = $api->getSubscriptionById($subscription_id);
 
-                if(isset($subscriptionData['type']) && $subscriptionData['type'] === 'subscription'){
+                if(isset($subscriptionData['data']['type']) && $subscriptionData['data']['type'] === 'subscription'){
                     $subscription_exists = true;
                 }
             }

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -289,7 +289,8 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             $data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
             do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
 
-            $subscription_id = get_post_meta('_ecurring_subscription_id', true);
+            $subscription_id = get_post_meta($order_id, '_ecurring_subscription_id', true);
+
             $subscription_exists = false;
 
             if($subscription_id) {

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -307,11 +307,6 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
                 $response = $api->createSubscription($data);
 
-                if ( isset( $response['errors'] ) ) {
-                    eCurring_WC_Plugin::debug( 'Creating eCurring subscription failed with error ' . print_r($response['errors'], TRUE ) );
-                    return array ( 'result' => 'failure' );
-                }
-
                 if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
                     $this->updateOrderWithSubscriptionData($response, $order);
                 }

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -340,24 +340,25 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 	protected function updateOrderWithSubscriptionData($order_id, $response)
     {
-        update_post_meta( $order_id, '_ecurring_subscription_id', $response['data']['id'] );
-        update_post_meta( $order_id, '_transaction_id', $response['data']['id'] );
+        $ecurring_subscription_id = $response['data']['id'];
+
+        update_post_meta( $order_id, '_ecurring_subscription_id',  $ecurring_subscription_id);
 
         $confirmation_page = $response['data']['attributes']['confirmation_page'];
         $subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];
         update_post_meta( $order_id, '_ecurring_subscription_link', $subscription_link );
 
         if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->id );
+            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $ecurring_subscription_id . ' created for order ' . $order->id );
         } else {
-            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $response['data']['id'] . ' created for order ' . $order->get_id() );
+            eCurring_WC_Plugin::debug( $this->id . ': Subscription ' . $ecurring_subscription_id . ' created for order ' . $order->get_id() );
         }
 
         $order->add_order_note( sprintf(
         /* translators: Placeholder 1: Payment method title, placeholder 2: payment ID */
             __( 'Manual %s payment started for subscription ID %s.', 'woo-ecurring' ),
             $this->method_title,
-            '<a href="'.$subscription_link.'" target="_blank">'.$response['data']['id'].'</a>'
+            '<a href="'.$subscription_link.'" target="_blank">'. $ecurring_subscription_id .'</a>'
         ) );
     }
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -294,13 +294,13 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 			$response = json_decode( $request, true );
 
+            if ( isset( $response['errors'] ) ) {
+                eCurring_WC_Plugin::debug( 'Creating eCurring subscription failed with error ' . print_r($response['errors'], TRUE ) );
+                return array ( 'result' => 'failure' );
+            }
+
 			if ( isset( $response['data'] ) && $response['data']['type'] == 'subscription' ) {
 				$this->updateOrderWithSubscriptionData($response, $order);
-			}
-
-			if ( isset( $response['errors'] ) ) {
-				eCurring_WC_Plugin::debug( 'Creating eCurring subscription failed with error ' . print_r($response['errors'], TRUE ) );
-				return array ( 'result' => 'failure' );
 			}
 
 			do_action( WOOECUR_PLUGIN_ID . '_payment_created', $request, $order );

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -350,9 +350,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		return array ( 'result' => 'failure' );
 	}
 
-	protected function updateOrderWithSubscriptionData(array $response, WC_Order $order)
+	protected function updateOrderWithSubscriptionData(array $subscription, WC_Order $order)
     {
-        $ecurring_subscription_id = $response['data']['id'];
+        $ecurring_subscription_id = $subscription['data']['id'];
 
         if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
             $order_id = $order->id;
@@ -362,7 +362,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
         update_post_meta( $order_id, '_ecurring_subscription_id',  $ecurring_subscription_id);
 
-        $confirmation_page = $response['data']['attributes']['confirmation_page'];
+        $confirmation_page = $subscription['data']['attributes']['confirmation_page'];
         $subscription_link = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmation_page)[5];
         update_post_meta( $order_id, '_ecurring_subscription_link', $subscription_link );
 

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -504,7 +504,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 		$api = eCurring_WC_Plugin::getApiHelper();
 		$eCurring_subscription_id = get_post_meta($order_id,'_ecurring_subscription_id',true);
 
-		$eCurring_subscription = json_decode($api->getSubscriptionById($eCurring_subscription_id),true)['data'];
+		$eCurring_subscription = $api->getSubscriptionById($eCurring_subscription_id)['data'];
 
 		$eCurring_subscription_attr = $eCurring_subscription['attributes'];
 		$mandate_data = array(

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -294,9 +294,9 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
             $subscription_exists = false;
 
             if($subscription_id) {
-                $subscriptionData = $api->getSubscriptionById($subscription_id);
+                $subscription_data = $api->getSubscriptionById($subscription_id);
 
-                if(isset($subscriptionData['data']['type']) && $subscriptionData['data']['type'] === 'subscription'){
+                if(isset($subscription_data['data']['type']) && $subscription_data['data']['type'] === 'subscription'){
                     $subscription_exists = true;
                 }
             }

--- a/includes/ecurring/wc/gateway/abstract.php
+++ b/includes/ecurring/wc/gateway/abstract.php
@@ -291,21 +291,14 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             $subscription_id = get_post_meta($order_id, '_ecurring_subscription_id', true);
 
-            $subscription_exists = false;
-
             if($subscription_id) {
                 $subscription_data = $api->getSubscriptionById($subscription_id);
-
-                $subscription_exists = true;
-            }
-
-            if(! $subscription_exists)
-            {
+            } else {
                 $raw_api_response = apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', null);
 
-                $response = $api->createSubscription($data);
+                $subscription_data = $api->createSubscription($data);
 
-                $this->updateOrderWithSubscriptionData($response, $order);
+                $this->updateOrderWithSubscriptionData($subscription_data, $order);
 
                 /**
                  * This action was triggered here before with unparsed api response data, so we have to do the same.
@@ -315,7 +308,7 @@ abstract class eCurring_WC_Gateway_Abstract extends WC_Payment_Gateway
                 do_action( WOOECUR_PLUGIN_ID . '_payment_created', $raw_api_response, $order );
             }
 
-			$redirect = isset( $response['error'] ) ? '' : $response['data']['attributes']['confirmation_page'] . '?accepted=true';
+			$redirect = isset( $response['error'] ) ? '' : $subscription_data['data']['attributes']['confirmation_page'] . '?accepted=true';
 
 			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 				eCurring_WC_Plugin::debug( "For order " . $order->id . " redirect user to eCurring Checkout URL: " . $redirect );

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -117,6 +117,6 @@ class eCurring_WC_Helper_Api
             return $result->get_error_message();
         }
 
-		return $result['body'];
+		return apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', $result['body'], $url, $args);
 	}
 }

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -116,7 +116,15 @@ class eCurring_WC_Helper_Api
 		if(is_wp_error($result)) {
             return $result->get_error_message();
         }
+		$response_body = $result['body'];
 
-		return apply_filters(WOOECUR_PLUGIN_ID . '_raw_api_response', $result['body'], $url, $args);
+		/**
+         * This is needed to keep backward compatibility. See WOOECUR_PLUGIN_ID . '_payment_created' action triggering for details.
+         */
+        add_filter(WOOECUR_PLUGIN_ID . '_raw_api_response', function() use ($response_body){
+            return $response_body;
+        });
+
+		return $response_body;
 	}
 }

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -19,11 +19,12 @@ class eCurring_WC_Helper_Api
      *
      * @param array $data
      *
-     * @return string API response body or error message.
+     * @return array API response body or error message.
+     * @throws eCurring_WC_Exception_ApiClientException
      */
 	public function createSubscription(array $data)
     {
-        return $this->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
+        return $this->doApiCallWithResultParsing('POST', 'https://api.ecurring.com/subscriptions', $data);
     }
 
     /**

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -14,22 +14,38 @@ class eCurring_WC_Helper_Api
 		$this->settings_helper = $settings_helper;
 	}
 
+    /**
+     * Send request for creating new eCurring subscription.
+     *
+     * @param array $data
+     *
+     * @return string API response body or error message.
+     */
 	public function createSubscription(array $data)
     {
         return $this->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
     }
 
+    /**
+     * Get subscription data using subscription id.
+     *
+     * @param string $subscription_id
+     *
+     * @return string Response body with subscription data or error message.
+     */
     public function getSubscriptionById($subscription_id)
     {
         return $this->apiCall('GET','https://api.ecurring.com/subscriptions/'.$subscription_id);
     }
 
 	/**
-	 * @param $method
-	 * @param $url
-	 * @param bool|array $data
+     * Make eCurring API request call.
+     *
+	 * @param string $method HTTP Method, one of the GET, POST, PATH, DELETE.
+	 * @param string $url Request target URL.
+	 * @param bool|array $data Content to be sent in JSON-encoded format as request body.
 	 *
-	 * @return mixed
+	 * @return string Response body or error message string.
 	 */
 	public function apiCall( $method, $url, $data = false ) {
 

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -16,6 +16,14 @@ class eCurring_WC_Helper_Api
 		$this->settings_helper = $settings_helper;
 	}
 
+	public function createSubscription(array $data, WC_Order $order)
+    {
+        $data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
+        do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
+
+        return $this->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
+    }
+
 	/**
 	 * @param $method
 	 * @param $url

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -34,6 +34,9 @@ class eCurring_WC_Helper_Api
      * @return array Subscription data.
      *
      * @see https://docs.ecurring.com/subscriptions/get Response data structure.
+     *
+     * @throws eCurring_WC_Exception_ApiClientException If cannot parse response.
+     *
      */
     public function getSubscriptionById($subscription_id)
     {
@@ -41,7 +44,13 @@ class eCurring_WC_Helper_Api
         $subscriptionData = json_decode($rawResponseBody, true);
 
         if(json_last_error() !== JSON_ERROR_NONE){
-            //todo: throw an exception here.
+            throw new eCurring_WC_Exception_ApiClientException(
+                sprintf(
+                    'Cannot parse API response. JSON parse error message: %1$s. Parsed string: %2$s',
+                    json_last_error_msg(),
+                    $rawResponseBody
+                )
+            );
         }
 
         return $subscriptionData;

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -14,11 +14,8 @@ class eCurring_WC_Helper_Api
 		$this->settings_helper = $settings_helper;
 	}
 
-	public function createSubscription(array $data, WC_Order $order)
+	public function createSubscription(array $data)
     {
-        $data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
-        do_action( WOOECUR_PLUGIN_ID . '_create_payment', $data, $order );
-
         return $this->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
     }
 

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -29,13 +29,22 @@ class eCurring_WC_Helper_Api
     /**
      * Get subscription data using subscription id.
      *
-     * @param string $subscription_id
+     * @param string $subscription_id The id of subscription to get from eCurring API.
      *
-     * @return string Response body with subscription data or error message.
+     * @return array Subscription data.
+     *
+     * @see https://docs.ecurring.com/subscriptions/get Response data structure.
      */
     public function getSubscriptionById($subscription_id)
     {
-        return $this->apiCall('GET','https://api.ecurring.com/subscriptions/'.$subscription_id);
+        $rawResponseBody = $this->apiCall('GET','https://api.ecurring.com/subscriptions/'.$subscription_id);
+        $subscriptionData = json_decode($rawResponseBody, true);
+
+        if(json_last_error() !== JSON_ERROR_NONE){
+            //todo: throw an exception here.
+        }
+
+        return $subscriptionData;
     }
 
 	/**

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -36,13 +36,19 @@ class eCurring_WC_Helper_Api
      * @see https://docs.ecurring.com/subscriptions/get Response data structure.
      *
      * @throws eCurring_WC_Exception_ApiClientException If cannot parse response.
-     *
      */
     public function getSubscriptionById($subscription_id)
     {
         $url = 'https://api.ecurring.com/subscriptions/'.$subscription_id;
 
         $subscriptionData = $this->doApiCallWithResultParsing('GET', $url);
+
+        if(isset($subscriptionData['errors'])){
+            throw new eCurring_WC_Exception_ApiClientException(
+                'Errors returned by the API. Returned response: %1$s',
+                print_r($subscriptionData, true)
+            );
+        }
 
         return $subscriptionData;
     }

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -2,8 +2,6 @@
 
 class eCurring_WC_Helper_Api
 {
-	protected static $api_client;
-
 	/**
 	 * @var eCurring_WC_Helper_Settings
 	 */

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -40,8 +40,31 @@ class eCurring_WC_Helper_Api
      */
     public function getSubscriptionById($subscription_id)
     {
-        $rawResponseBody = $this->apiCall('GET','https://api.ecurring.com/subscriptions/'.$subscription_id);
-        $subscriptionData = json_decode($rawResponseBody, true);
+        $url = 'https://api.ecurring.com/subscriptions/'.$subscription_id;
+
+        $subscriptionData = $this->doApiCallWithResultParsing('GET', $url);
+
+        return $subscriptionData;
+    }
+
+    /**
+     * Do API call and parse results.
+     *
+     * This function is needed to call existing apiCall, parse results and throw en exception if something wrong.
+     * That function exists for backward compatibility and should be removed or updated in the future.
+     *
+     * @param string     $method HTTP Method, one of the GET, POST, PATH, DELETE.
+     * @param string     $url    Request target URL.
+     * @param bool|array $data   Content to be sent in JSON-encoded format as request body.
+     *
+     * @return array Response data.
+     *
+     * @throws eCurring_WC_Exception_ApiClientException If cannot parse response.
+     */
+    protected function doApiCallWithResultParsing($method, $url, $data = false)
+    {
+        $rawResponseBody = $this->apiCall($method, $url, $data);
+        $parsedResponse = json_decode($rawResponseBody, true);
 
         if(json_last_error() !== JSON_ERROR_NONE){
             throw new eCurring_WC_Exception_ApiClientException(
@@ -53,7 +76,7 @@ class eCurring_WC_Helper_Api
             );
         }
 
-        return $subscriptionData;
+        return $parsedResponse;
     }
 
 	/**

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -65,7 +65,7 @@ class eCurring_WC_Helper_Api
      *
      * @return array Response data.
      *
-     * @throws eCurring_WC_Exception_ApiClientException If cannot parse response.
+     * @throws eCurring_WC_Exception_ApiClientException If cannot parse response or error returned.
      */
     protected function doApiCallWithResultParsing($method, $url, $data = false)
     {
@@ -78,6 +78,15 @@ class eCurring_WC_Helper_Api
                     'Cannot parse API response. JSON parse error message: %1$s. Parsed string: %2$s',
                     json_last_error_msg(),
                     $rawResponseBody
+                )
+            );
+        }
+
+        if (isset($parsedResponse['errors'])) {
+            throw new eCurring_WC_Exception_ApiClientException(
+                sprintf(
+                    'API response contains error data. Details: %1$s',
+                    print_r($parsedResponse['errors'], true)
                 )
             );
         }

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -19,6 +19,11 @@ class eCurring_WC_Helper_Api
         return $this->apiCall( 'POST', 'https://api.ecurring.com/subscriptions', $data );
     }
 
+    public function getSubscriptionById($subscription_id)
+    {
+        return $this->apiCall('GET','https://api.ecurring.com/subscriptions/'.$subscription_id);
+    }
+
 	/**
 	 * @param $method
 	 * @param $url

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -41,16 +41,7 @@ class eCurring_WC_Helper_Api
     {
         $url = 'https://api.ecurring.com/subscriptions/'.$subscription_id;
 
-        $subscriptionData = $this->doApiCallWithResultParsing('GET', $url);
-
-        if(isset($subscriptionData['errors'])){
-            throw new eCurring_WC_Exception_ApiClientException(
-                'Errors returned by the API. Returned response: %1$s',
-                print_r($subscriptionData, true)
-            );
-        }
-
-        return $subscriptionData;
+        return $this->doApiCallWithResultParsing('GET', $url);
     }
 
     /**
@@ -85,7 +76,7 @@ class eCurring_WC_Helper_Api
         if (isset($parsedResponse['errors'])) {
             throw new eCurring_WC_Exception_ApiClientException(
                 sprintf(
-                    'API response contains error data. Details: %1$s',
+                    'Errors returned by the API. Returned response: %1$s',
                     print_r($parsedResponse['errors'], true)
                 )
             );

--- a/includes/ecurring/wc/helper/api.php
+++ b/includes/ecurring/wc/helper/api.php
@@ -27,7 +27,6 @@ class eCurring_WC_Helper_Api
 	/**
 	 * @param $method
 	 * @param $url
-	 * @param $apiKey
 	 * @param bool|array $data
 	 *
 	 * @return mixed

--- a/tests/Stubs/wp-admin/includes/plugin.php
+++ b/tests/Stubs/wp-admin/includes/plugin.php
@@ -1,0 +1,1 @@
+<?php //nothing here

--- a/tests/Unit/Gateway_AbstractTest.php
+++ b/tests/Unit/Gateway_AbstractTest.php
@@ -5,13 +5,17 @@ namespace eCurring\WooEcurringTests\Unit;
 
 
 use eCurring\WooEcurringTests\TestCase;
+use eCurring_WC_Exception_ApiClientException;
 use eCurring_WC_Gateway_Abstract;
 use eCurring_WC_Helper_Api;
 use eCurring_WC_Helper_Data;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
 use WC_Order;
+use WC_Order_Item_Product;
+use function Brain\Monkey\Functions\expect;
 
 class Gateway_AbstractTest extends TestCase
 {
@@ -20,21 +24,39 @@ class Gateway_AbstractTest extends TestCase
     public function testProcess_payment()
     {
         $orderId = 123;
+        $ecurring_customer_id = '456';
+        $ecurring_subscription_plan_id = '789';
+        $product_id = 100;
+        $order_key = 'abc';
+        $subscription_data = [];
         $wcOrderMock = Mockery::mock(WC_Order::class);
-
+        $wcOrderMock->shouldReceive('get_order_key')
+            ->andReturn($order_key);
         $wcOrderMock->shouldReceive('get_id')
             ->andReturn($orderId);
+        $wcOrderItemMock = Mockery::mock(WC_Order_Item_Product::class);
+        $wcOrderItemMock->shouldReceive('get_product_id')
+            ->andReturn($product_id);
+        $wcOrderMock->shouldReceive('get_items')
+            ->andReturn([$wcOrderItemMock]);
         $ecurringPluginMock = Mockery::mock('alias:eCurring_WC_Plugin');
         $dataHelperMock = $this->createMock(eCurring_WC_Helper_Data::class);
         $dataHelperMock->expects($this->once())
             ->method('getWcOrder')
             ->with($orderId)
             ->willReturn($wcOrderMock);
+        $dataHelperMock->expects($this->once())
+            ->method('getUsereCurringCustomerId')
+            ->willReturn($ecurring_customer_id);
         $ecurringPluginMock->shouldReceive('getDataHelper')
             ->andReturn($dataHelperMock);
         $ecurringPluginMock->shouldReceive('debug');
         $ecurringPluginMock->shouldReceive('addNotice');
         $apiHelperMock = Mockery::mock(eCurring_WC_Helper_Api::class);
+        $apiHelperMock->shouldReceive('getSubscriptionById')
+            ->andThrow(eCurring_WC_Exception_ApiClientException::class, 'this is the test exception');
+        $apiHelperMock->shouldReceive('createSubscription')
+            ->andReturn($subscription_data);
         $ecurringPluginMock->shouldReceive('getApiHelper')
             ->andReturn($apiHelperMock);
 
@@ -43,6 +65,36 @@ class Gateway_AbstractTest extends TestCase
         $sut = $this->getMockForAbstractClass(eCurring_WC_Gateway_Abstract::class, [], '', false);
         $sut->id = strtolower(get_class($sut));
 
-        $sut->process_payment($orderId);
+        expect('update_post_meta')->with(
+            $orderId,
+            'ecurring_woocommerce_mandate_accepted_date',
+            date('Y-m-d H:i:s')
+        );
+        expect('__')->andReturnFirstArg();
+        expect('get_post_meta')->with($orderId, '_ecurring_subscription_plan', true)
+            ->andReturn($ecurring_subscription_plan_id);
+        expect('add_query_arg');
+        $siteUrl = 'localtest.loc';
+        expect('get_site_url')
+            ->withNoArgs()
+            ->andReturn($siteUrl);
+        $wcMock = Mockery::mock(stdClass::class);
+        $wcMock->shouldReceive('api_request_url')
+            ->andReturn($siteUrl);
+        expect('WC')
+            ->andReturn($wcMock);
+        expect('home_url')
+            ->andReturn($siteUrl);
+        expect('is_plugin_active')
+            ->with('polylang/polylang.php')
+            ->andReturn(false);
+
+        define('ABSPATH', dirname(__DIR__) .  '/Stubs/');
+        define('WOOECUR_PLUGIN_ID', 'woocommerce_ecurring');
+
+        $result = $sut->process_payment($orderId);
+
+
+        $this->assertSame('success', $result['result']);
     }
 }

--- a/tests/Unit/Gateway_AbstractTest.php
+++ b/tests/Unit/Gateway_AbstractTest.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace eCurring\WooEcurringTests\Unit;
+
+
+use eCurring\WooEcurringTests\TestCase;
+use eCurring_WC_Gateway_Abstract;
+use eCurring_WC_Helper_Api;
+use eCurring_WC_Helper_Data;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Order;
+
+class Gateway_AbstractTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testProcess_payment()
+    {
+        $orderId = 123;
+        $wcOrderMock = Mockery::mock(WC_Order::class);
+
+        $wcOrderMock->shouldReceive('get_id')
+            ->andReturn($orderId);
+        $ecurringPluginMock = Mockery::mock('alias:eCurring_WC_Plugin');
+        $dataHelperMock = $this->createMock(eCurring_WC_Helper_Data::class);
+        $dataHelperMock->expects($this->once())
+            ->method('getWcOrder')
+            ->with($orderId)
+            ->willReturn($wcOrderMock);
+        $ecurringPluginMock->shouldReceive('getDataHelper')
+            ->andReturn($dataHelperMock);
+        $ecurringPluginMock->shouldReceive('debug');
+        $ecurringPluginMock->shouldReceive('addNotice');
+        $apiHelperMock = Mockery::mock(eCurring_WC_Helper_Api::class);
+        $ecurringPluginMock->shouldReceive('getApiHelper')
+            ->andReturn($apiHelperMock);
+
+
+        /** @var eCurring_WC_Gateway_Abstract&MockObject $sut */
+        $sut = $this->getMockForAbstractClass(eCurring_WC_Gateway_Abstract::class, [], '', false);
+        $sut->id = strtolower(get_class($sut));
+
+        $sut->process_payment($orderId);
+    }
+}


### PR DESCRIPTION
Addresses [ECUR-20](https://inpsyde.atlassian.net/browse/ECUR-20) issue.

The main change: don't create a new subscription on payment processing if order already has associated subscription and that subscription exists on remote eCurring server.

Also, a bit of refactoring, where it needed to implement changes.