### PR TITLE
Rename plugin to Mollie Subscriptions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooCommerce eCurring gateway ===
+=== Mollie Subscriptions ===
 Contributors: davdebcom, inpsyde
 Tags: recurring payments, woocommerce, payment gateway, direct debit, subscriptions, woocommerce subscriptions, sepa
 Requires at least: 4.6
@@ -114,7 +114,7 @@ Where possible, also include the eCurring log file. You can find the eCurring lo
 
 = Automatic installation =
 
-1. Install the plugin via Plugins -> New plugin. Search for 'WooCommerce eCurring gateway'.
+1. Install the plugin via Plugins -> New plugin. Search for 'Mollie Subscriptions'.
 2. Activate the 'eCurring for WooCommerce' plugin through the 'Plugins' menu in WordPress
 3. Set your eCurring API key at WooCommerce -> Settings -> Checkout (or use the *eCurring Settings* link in the Plugins overview)
 4. You're done, the active payment methods should be visible in the checkout of your webshop.

--- a/woo-ecurring.php
+++ b/woo-ecurring.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce eCurring gateway
+ * Plugin Name: Mollie Subscriptions
  * Plugin URI: https://www.ecurring.com/
  * Description: Collect your subscription fees in WooCommerce with ease.
  * Version: 1.2.0
@@ -148,7 +148,7 @@ function ecurring_wc_plugin_inactive_json_extension() {
 	}
 
 	echo '<div class="error"><p>';
-	echo esc_html__( 'WooCommerce eCurring gateway requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.', 'woo-ecurring' );
+	echo esc_html__( 'Mollie Subscriptions requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.', 'woo-ecurring' );
 	echo '</p></div>';
 
 	return false;

--- a/woo-ecurring.php
+++ b/woo-ecurring.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.ecurring.com/
  * Description: Collect your subscription fees in WooCommerce with ease.
  * Version: 1.2.0
- * Author: eCurring
+ * Author: Mollie
  * Requires at least: 4.6
  * Tested up to: 5.3
  * Text Domain: woo-ecurring


### PR DESCRIPTION
Addresses [ECUR-49](https://inpsyde.atlassian.net/browse/ECUR-49).

Rename plugin in the main plugin file from WooCommerce eCurring gateway to Mollie subscriptions so new plugin title will be displayed. The main plugin file name and text domain can be left as is for now.