### PR TITLE
Create a new subscription on Mollie payment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^5.6.40 | ^7.0"
+        "php": "^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e6b6d1248cff4726cd27f0b9421c91b",
+    "content-hash": "d8022cd1fa50c1182f097de26429038f",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc25ac95d446b87bd0155f2cf3aed39c",
+    "content-hash": "5e6b6d1248cff4726cd27f0b9421c91b",
     "packages": [],
     "packages-dev": [
         {
@@ -53,16 +53,16 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956"
+                "reference": "a11f7a0e703ff92a91b67bbf9ea384ab0ec2c863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
-                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/a11f7a0e703ff92a91b67bbf9ea384ab0ec2c863",
+                "reference": "a11f7a0e703ff92a91b67bbf9ea384ab0ec2c863",
                 "shasum": ""
             },
             "require": {
@@ -71,9 +71,9 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7",
                 "phpcompatibility/php-compatibility": "^9.3.0",
-                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -115,7 +115,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2019-11-24T16:03:21+00:00"
+            "time": "2020-10-05T08:24:45+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -589,28 +589,28 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160"
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b20034be5efcdab4fb60ca3a29cba2949aead160",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2",
-                "phpdocumentor/reflection-docblock": "^5.0",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
             },
             "type": "library",
             "extra": {
@@ -648,7 +648,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-07-08T12:44:21+00:00"
+            "time": "2020-09-29T09:10:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1731,7 +1731,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6.40 | ^7.0"
+        "php": "^7.2"
     },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -1,6 +1,7 @@
 <?php
 
 
+use Ecurring\WooEcurring\EventListener\PaymentCompleteEventListener;
 use Ecurring\WooEcurring\PaymentGatewaysFilter\WhitelistedRecurringPaymentGatewaysFilter;
 use Ecurring\WooEcurring\Api\ApiClient;
 use Ecurring\WooEcurring\EventListener\MolliePaymentEventListener;
@@ -42,6 +43,7 @@ class eCurring_WC_Plugin
 
 		$apiClient = new ApiClient($settingsHelper->getApiKey());
         (new MolliePaymentEventListener($apiClient, $data_helper, $subscriptonCrud))->init();
+        (new PaymentCompleteEventListener($apiClient, $subscriptonCrud))->init();
 
 
 		// When page 'WooCommerce -> Checkout -> Checkout Options' is saved

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,5 +1,6 @@
 {
   "redefinable-internals": [
-    "get_class"
+    "get_class",
+    "date"
   ]
 }

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -17,7 +17,7 @@ class ApiClient {
 	}
 
 	/**
-	 * Send request for creating new eCurring subscription.
+	 * Send request for creating new eCurring subscription and activating it immediately.
 	 *
 	 * @param        $ecurringCustomerId
 	 * @param        $subscriptionPlanId
@@ -42,6 +42,7 @@ class ApiClient {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
 					'confirmation_sent'        => 'true', // todo: check if we need this
+					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -41,7 +41,9 @@ class ApiClient {
 					'subscription_plan_id'     => $subscriptionPlanId,
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
-					'confirmation_sent'        => 'true', // todo: check if we need this
+					'confirmation_sent'        => 'true', // todo: check if we need this,
+					'mandate_accepted'         => 'true',
+					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -161,7 +161,7 @@ class ApiClient implements ApiClientInterface {
 
 		return $this->apiCall(
 			'PATCH',
-			'https://api.ecurring.com/subscriptions',
+			sprintf('https://api.ecurring.com/subscriptions/%1$s', $subscriptionId),
 			$requestData
 		);
 	}

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\Api;
 
 class ApiClient implements ApiClientInterface {

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -145,7 +145,7 @@ class ApiClient implements ApiClientInterface {
 	/**
 	 * @inheritdoc
 	 */
-	public function activateSubscription( string $subscriptionId ): array {
+	public function activateSubscription( string $subscriptionId, string $mandateAcceptedDate ): array {
 
 		$requestData = [
 			'data' => [
@@ -154,7 +154,7 @@ class ApiClient implements ApiClientInterface {
 				'attributes' => [
 					'status' => 'active',
 					'mandate_accepted' => true,
-					'mandate_accepted_date' => date('c'), //todo: use the date from actual subscription data
+					'mandate_accepted_date' => $mandateAcceptedDate
 				]
 			]
 		];

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -42,7 +42,7 @@ class ApiClient {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
 					'confirmation_sent'        => 'true', // todo: check if we need this,
-					'mandate_accepted'         => 'true',
+					'mandate_accepted'         => true,
 					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -141,4 +141,28 @@ class ApiClient implements ApiClientInterface {
 
 		return $parsedResponse;
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function activateSubscription( string $subscriptionId ): array {
+
+		$requestData = [
+			'data' => [
+				'type' => 'subscription',
+				'id' => $subscriptionId,
+				'attributes' => [
+					'status' => 'active',
+					'mandate_accepted' => true,
+					'mandate_accepted_date' => date('c'), //todo: use the date from actual subscription data
+				]
+			]
+		];
+
+		return $this->apiCall(
+			'PATCH',
+			'https://api.ecurring.com/subscriptions',
+			$requestData
+		);
+	}
 }

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -2,7 +2,7 @@
 
 namespace Ecurring\WooEcurring\Api;
 
-class ApiClient {
+class ApiClient implements ApiClientInterface {
 
 	/**
 	 * @var string
@@ -17,22 +17,14 @@ class ApiClient {
 	}
 
 	/**
-	 * Send request for creating new eCurring subscription.
-	 *
-	 * @param        $ecurringCustomerId
-	 * @param        $subscriptionPlanId
-	 * @param string $subscriptionWebhookUrl
-	 * @param string $transactionWebhookUrl
-	 *
-	 * @return array API response body or error message.
-	 * @throws ApiClientException
+	 * @inheritDoc
 	 */
 	public function createSubscription(
-		$ecurringCustomerId,
-		$subscriptionPlanId,
-		$subscriptionWebhookUrl = '',
-		$transactionWebhookUrl = ''
-	) {
+		string $ecurringCustomerId,
+		string $subscriptionPlanId,
+		string $subscriptionWebhookUrl = '',
+		string $transactionWebhookUrl = ''
+	): array {
 		$requestData = [
 			'data' => [
 				'type'       => 'subscription',
@@ -55,17 +47,9 @@ class ApiClient {
 	}
 
 	/**
-	 * Get subscription data using subscription id.
-	 *
-	 * @param string $subscription_id The id of subscription to get from eCurring API.
-	 *
-	 * @return array Subscription data.
-	 *
-	 * @see https://docs.ecurring.com/subscriptions/get Response data structure.
-	 *
-	 * @throws ApiClientException If cannot parse response.
+	 * @inheritDoc
 	 */
-	public function getSubscriptionById($subscription_id)
+	public function getSubscriptionById($subscription_id): array
 	{
 		$url = 'https://api.ecurring.com/subscriptions/'.$subscription_id;
 
@@ -83,7 +67,7 @@ class ApiClient {
 	 *
 	 * @throws ApiClientException
 	 */
-	public function apiCall( $method, $url, $data = false ) {
+	public function apiCall( $method, $url, $data = false ): array {
 
 		$rawResponse = $this->doApiRequest($method, $url, $data);
 

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -57,6 +57,30 @@ class ApiClient implements ApiClientInterface {
 	}
 
 	/**
+	 * @inheritdoc
+	 */
+	public function activateSubscription( string $subscriptionId, string $mandateAcceptedDate ): array {
+
+		$requestData = [
+			'data' => [
+				'type' => 'subscription',
+				'id' => $subscriptionId,
+				'attributes' => [
+					'status' => 'active',
+					'mandate_accepted' => true,
+					'mandate_accepted_date' => $mandateAcceptedDate
+				]
+			]
+		];
+
+		return $this->apiCall(
+			'PATCH',
+			sprintf('https://api.ecurring.com/subscriptions/%1$s', $subscriptionId),
+			$requestData
+		);
+	}
+
+	/**
 	 * Make eCurring API request call.
 	 *
 	 * @param string     $method HTTP Method, one of the GET, POST, PATH, DELETE.
@@ -140,29 +164,5 @@ class ApiClient implements ApiClientInterface {
 		}
 
 		return $parsedResponse;
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function activateSubscription( string $subscriptionId, string $mandateAcceptedDate ): array {
-
-		$requestData = [
-			'data' => [
-				'type' => 'subscription',
-				'id' => $subscriptionId,
-				'attributes' => [
-					'status' => 'active',
-					'mandate_accepted' => true,
-					'mandate_accepted_date' => $mandateAcceptedDate
-				]
-			]
-		];
-
-		return $this->apiCall(
-			'PATCH',
-			sprintf('https://api.ecurring.com/subscriptions/%1$s', $subscriptionId),
-			$requestData
-		);
 	}
 }

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -41,7 +41,7 @@ class ApiClient {
 					'subscription_plan_id'     => $subscriptionPlanId,
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
-					'confirmation_sent'        => 'true', // todo: check if we need this,
+					'confirmation_sent'        => true, // todo: check if we need this,
 					'mandate_accepted'         => true,
 					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -17,7 +17,7 @@ class ApiClient {
 	}
 
 	/**
-	 * Send request for creating new eCurring subscription and activating it immediately.
+	 * Send request for creating new eCurring subscription.
 	 *
 	 * @param        $ecurringCustomerId
 	 * @param        $subscriptionPlanId
@@ -42,9 +42,6 @@ class ApiClient {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
 					'confirmation_sent'        => true, // todo: check if we need this,
-					'mandate_accepted'         => true,
-					'mandate_accepted_date'    => date('c'),
-					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -40,8 +40,8 @@ class ApiClient {
 					'customer_id'              => $ecurringCustomerId,
 					'subscription_plan_id'     => $subscriptionPlanId,
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
-					'transaction_webhook_url'  => $transactionWebhookUrl,
-					'confirmation_sent'        => 'true',
+					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
+					'confirmation_sent'        => 'true', // todo: check if we need this
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -22,7 +22,6 @@ class ApiClient implements ApiClientInterface {
 	public function createSubscription(
 		string $ecurringCustomerId,
 		string $subscriptionPlanId,
-		string $subscriptionWebhookUrl = '',
 		string $transactionWebhookUrl = ''
 	): array {
 		$requestData = [
@@ -31,9 +30,8 @@ class ApiClient implements ApiClientInterface {
 				'attributes' => [
 					'customer_id'              => $ecurringCustomerId,
 					'subscription_plan_id'     => $subscriptionPlanId,
-					'subscription_webhook_url' => $subscriptionWebhookUrl,
-					'transaction_webhook_url'  => $transactionWebhookUrl, //todo: check if we still need this
-					'confirmation_sent'        => true, // todo: check if we need this,
+					'transaction_webhook_url'  => $transactionWebhookUrl,
+					'confirmation_sent'        => true,
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -12,7 +12,7 @@ class ApiClient implements ApiClientInterface {
 	/**
 	 * @param string $apiKey Key required for authentication.
 	 */
-	public function __construct($apiKey) {
+	public function __construct(string $apiKey) {
 		$this->apiKey = $apiKey;
 	}
 

--- a/src/Api/ApiClientException.php
+++ b/src/Api/ApiClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\Api;
 
 use eCurring_WC_Exception;

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -32,4 +32,12 @@ interface ApiClientInterface {
 	 * @return array Subscription data or request error details.
 	 */
 	public function getSubscriptionById(string $subscriptionId): array;
+
+	/**
+	 * @param string $subscriptionId
+	 *
+	 * @return array Subscription data or request error details.
+	 */
+	public function activateSubscription(string $subscriptionId): array;
+
 }

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -24,7 +24,6 @@ interface ApiClientInterface {
 	public function createSubscription(
 		string $customerId,
 		string $subscriptionId,
-		string $subscriptionWebhookUrl = '',
 		string $transactionWebhookUrl = ''
 	): array;
 

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecurring\WooEcurring\Api;
+
+/**
+ * Service able to interact with eCurring API.
+ */
+interface ApiClientInterface {
+
+	/**
+	 * API call to create subscription.
+	 *
+	 * @param string $customerId eCurring customer id.
+	 * @param string $subscriptionId eCurring subscription product id.
+	 * @param string $subscriptionWebhookUrl Webhook URL will be triggered by eCurring on subscription changes.
+	 * @param string $transactionWebhookUrl Webhook URL will be triggered by eCurring on transaction.
+	 *
+	 * @return array Created subscription data or error details.
+	 */
+	public function createSubscription(
+		string $customerId,
+		string $subscriptionId,
+		string $subscriptionWebhookUrl = '',
+		string $transactionWebhookUrl = ''
+	): array;
+
+	/**
+	 * @param string $subscriptionId
+	 *
+	 * @return array Subscription data or request error details.
+	 */
+	public function getSubscriptionById(string $subscriptionId): array;
+}

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -38,12 +38,14 @@ interface ApiClientInterface {
 	public function getSubscriptionById(string $subscriptionId): array;
 
 	/**
-	 * @param string $subscriptionId
+	 * @param string $subscriptionId Id of the subscription to activate.
+	 *
+	 * @param string $mandateAcceptedDate Date string formatted according to ISO 8601.
 	 *
 	 * @return array Subscription data or request error details.
 	 *
 	 * @throws ApiClientException If request failed.
 	 */
-	public function activateSubscription(string $subscriptionId): array;
+	public function activateSubscription(string $subscriptionId, string $mandateAcceptedDate): array;
 
 }

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -18,6 +18,8 @@ interface ApiClientInterface {
 	 * @param string $transactionWebhookUrl Webhook URL will be triggered by eCurring on transaction.
 	 *
 	 * @return array Created subscription data or error details.
+	 *
+	 * @throws ApiClientException If request failed.
 	 */
 	public function createSubscription(
 		string $customerId,
@@ -30,6 +32,8 @@ interface ApiClientInterface {
 	 * @param string $subscriptionId
 	 *
 	 * @return array Subscription data or request error details.
+	 *
+	 * @throws ApiClientException If request failed.
 	 */
 	public function getSubscriptionById(string $subscriptionId): array;
 
@@ -37,6 +41,8 @@ interface ApiClientInterface {
 	 * @param string $subscriptionId
 	 *
 	 * @return array Subscription data or request error details.
+	 *
+	 * @throws ApiClientException If request failed.
 	 */
 	public function activateSubscription(string $subscriptionId): array;
 

--- a/src/Api/ApiClientInterface.php
+++ b/src/Api/ApiClientInterface.php
@@ -42,7 +42,7 @@ interface ApiClientInterface {
 	 *
 	 * @param string $mandateAcceptedDate Date string formatted according to ISO 8601.
 	 *
-	 * @return array Subscription data or request error details.
+	 * @return array Subscription data.
 	 *
 	 * @throws ApiClientException If request failed.
 	 */

--- a/src/EnvironmentChecker.php
+++ b/src/EnvironmentChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring;
 
 

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -88,16 +88,17 @@ class MolliePaymentEventListener {
 	/**
 	 * Create an eCurring subscription on eCurring side using subscription product.
 	 *
-	 * @param WC_Product $product
+	 * @param WC_Order $order
+	 * @param string   $subscriptionId
 	 *
 	 * @return array
 	 * @throws ApiClientException
 	 */
-	protected function createEcurringSubscriptionForProduct( WC_Order $order, WC_Product $product ) {
+	protected function createEcurringSubscriptionForProduct( WC_Order $order, $subscriptionId ) {
 
 		return $this->apiClient->createSubscription(
 			$this->dataHelper->getUsereCurringCustomerId( $order ),
-			$this->subscriptionCrud->getProductSubscriptionId($product),
+			$subscriptionId,
 			add_query_arg( 'ecurring-webhook', 'subscription', home_url( '/' ) ),
 			add_query_arg( 'ecurring-webhook', 'transaction', home_url( '/' ) )
 		);

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -11,7 +11,6 @@ use Exception;
 use Mollie\Api\Resources\Payment;
 use WC_Order;
 use WC_Order_Item_Product;
-use WC_Product;
 
 /**
  * Listens for the Mollie payment create action.
@@ -69,8 +68,9 @@ class MolliePaymentEventListener {
 				try {
 					$product = $item->get_product();
 					$subscriptionId = $this->subscriptionCrud->getProductSubscriptionId($product);
+
 					if ( $subscriptionId !== null ) {
-						$subscriptionData = $this->createEcurringSubscriptionForProduct( $order, $product );
+						$subscriptionData = $this->createEcurringSubscriptionForProduct( $order, $subscriptionId );
 						$this->subscriptionCrud->saveSubscription($subscriptionData, $order);
 					}
 				} catch ( Exception $exception ) {

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -129,12 +129,11 @@ class MolliePaymentEventListener {
 	 * @return array
 	 * @throws ApiClientException
 	 */
-	protected function createEcurringSubscription( WC_Order $order, $subscriptionId ) {
+	protected function createEcurringSubscription( WC_Order $order, string $subscriptionId ) {
 
 		return $this->apiClient->createSubscription(
 			$this->dataHelper->getUsereCurringCustomerId( $order ),
 			$subscriptionId,
-			add_query_arg( 'ecurring-webhook', 'subscription', home_url( '/' ) ),
 			add_query_arg( 'ecurring-webhook', 'transaction', home_url( '/' ) )
 		);
 	}

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -74,7 +74,7 @@ class MolliePaymentEventListener {
 					$product = $item->get_product();
 					$subscriptionId = $this->subscriptionCrud->getProductSubscriptionId($product);
 
-					if ( $subscriptionId !== null ) {
+					if ( $subscriptionId !== null && ! $this->subscriptionForOrderExists($order)) {
 						$subscriptionData = $this->createEcurringSubscriptionForProduct( $order, $subscriptionId );
 						$this->subscriptionCrud->saveSubscription($subscriptionData, $order);
 					}
@@ -88,6 +88,24 @@ class MolliePaymentEventListener {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Check if subscription already created for given order.
+	 *
+	 * @param WC_Order $order
+	 *
+	 * @return bool
+	 */
+	protected function subscriptionForOrderExists(WC_Order $order): bool
+	{
+		$subscriptionId = $this->subscriptionCrud->getSubscriptionIdByOrder($order);
+
+		if($subscriptionId === null){
+			return false;
+		}
+
+		return isset($subscriptionData['data']['type']) && $subscriptionData['data']['type'] === 'subscription';
 	}
 
 	/**

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -75,7 +75,7 @@ class MolliePaymentEventListener {
 					$subscriptionId = $this->subscriptionCrud->getProductSubscriptionId($product);
 
 					if ( $subscriptionId !== null && ! $this->subscriptionForOrderExists($order)) {
-						$subscriptionData = $this->createEcurringSubscriptionForProduct( $order, $subscriptionId );
+						$subscriptionData = $this->createEcurringSubscription( $order, $subscriptionId );
 						$this->subscriptionCrud->saveSubscription($subscriptionData, $order);
 					}
 				} catch ( Exception $exception ) {
@@ -117,7 +117,7 @@ class MolliePaymentEventListener {
 	 * @return array
 	 * @throws ApiClientException
 	 */
-	protected function createEcurringSubscriptionForProduct( WC_Order $order, $subscriptionId ) {
+	protected function createEcurringSubscription( WC_Order $order, $subscriptionId ) {
 
 		return $this->apiClient->createSubscription(
 			$this->dataHelper->getUsereCurringCustomerId( $order ),

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -68,13 +68,25 @@ class MolliePaymentEventListener {
 	 */
 	public function onMolliePaymentCreated($payment, WC_Order $order ) {
 
+		if( $this->subscriptionForOrderExists($order) )
+		{
+			eCurring_WC_Plugin::debug(
+				sprintf(
+					'Subscription already exists for order %1$d. New subscription will not be created.',
+					$order->get_id()
+				)
+			);
+
+			return;
+		}
+
 		foreach ( $order->get_items() as $item ) {
 			if ( $item instanceof WC_Order_Item_Product ) {
 				try {
 					$product = $item->get_product();
 					$subscriptionId = $this->subscriptionCrud->getProductSubscriptionId($product);
 
-					if ( $subscriptionId !== null && ! $this->subscriptionForOrderExists($order)) {
+					if ( $subscriptionId !== null ) {
 						$subscriptionData = $this->createEcurringSubscription( $order, $subscriptionId );
 						$this->subscriptionCrud->saveSubscription($subscriptionData, $order);
 					}

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -51,7 +51,12 @@ class MolliePaymentEventListener {
 	 * Init event listener.
 	 */
 	public function init(){
-		add_action('mollie-payments-for-woocommerce_payment_created', [$this, 'onMolliePaymentCreated']);
+		add_action(
+			'mollie-payments-for-woocommerce_payment_created',
+			[$this, 'onMolliePaymentCreated'],
+			10,
+			2
+		);
 	}
 
 	/**

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -68,7 +68,8 @@ class MolliePaymentEventListener {
 			if ( $item instanceof WC_Order_Item_Product ) {
 				try {
 					$product = $item->get_product();
-					if ( $this->isProductIsEcurringSubscription( $product ) ) {
+					$subscriptionId = $this->subscriptionCrud->getProductSubscriptionId($product);
+					if ( $subscriptionId !== null ) {
 						$subscriptionData = $this->createEcurringSubscriptionForProduct( $order, $product );
 						$this->subscriptionCrud->saveSubscription($subscriptionData, $order);
 					}
@@ -82,17 +83,6 @@ class MolliePaymentEventListener {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Check if given product is eCurring subscription.
-	 *
-	 * @param WC_Product $product WC product to check.
-	 *
-	 * @return bool
-	 */
-	protected function isProductIsEcurringSubscription(WC_Product $product){
-		return $product->meta_exists(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_PLAN_FIELD);
 	}
 
 	/**

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\EventListener;
 
 use Ecurring\WooEcurring\Api\ApiClient;

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -119,6 +119,8 @@ class MolliePaymentEventListener {
 			return false;
 		}
 
+		$subscriptionData = $this->apiClient->getSubscriptionById($subscriptionId);
+
 		return isset($subscriptionData['data']['type']) && $subscriptionData['data']['type'] === 'subscription';
 	}
 

--- a/src/EventListener/MolliePaymentEventListener.php
+++ b/src/EventListener/MolliePaymentEventListener.php
@@ -119,7 +119,18 @@ class MolliePaymentEventListener {
 			return false;
 		}
 
-		$subscriptionData = $this->apiClient->getSubscriptionById($subscriptionId);
+		try{
+			$subscriptionData = $this->apiClient->getSubscriptionById($subscriptionId);
+		} catch (ApiClientException $exception)
+		{
+			eCurring_WC_Plugin::debug(
+				sprintf(
+					'Failed to check if subscription %1$s exists, caught API client exception. Exception message: %2$s',
+					$subscriptionId,
+					$exception->getMessage()
+				)
+			);
+		}
 
 		return isset($subscriptionData['data']['type']) && $subscriptionData['data']['type'] === 'subscription';
 	}

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\EventListener;
 
 use Ecurring\WooEcurring\Api\ApiClientException;

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -33,6 +33,9 @@ class PaymentCompleteEventListener {
 		$order = wc_get_order($orderId);
 		$subscriptionId = $order->get_meta(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true);
 
-		$this->apiClient->activateSubscription($subscriptionId);
+		if($subscriptionId){
+			$this->apiClient->activateSubscription($subscriptionId);
+		}
+
 	}
 }

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -43,7 +43,7 @@ class PaymentCompleteEventListener {
 		if($subscriptionId){
 			eCurring_WC_Plugin::debug(
 				sprintf(
-					'Payment completed for order %1$d. Subscription id is %1$s, trying to activate it.',
+					'Payment completed for order %1$d. Subscription id is %2$s, trying to activate it.',
 					$order->get_id(),
 					$subscriptionId
 				)

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -5,6 +5,7 @@ namespace Ecurring\WooEcurring\EventListener;
 
 
 use Ecurring\WooEcurring\Api\ApiClientInterface;
+use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;
 
 class PaymentCompleteEventListener {
 	/**
@@ -23,5 +24,17 @@ class PaymentCompleteEventListener {
 	public function init()
 	{
 		add_action('woocommerce_payment_complete', [$this, 'onPaymentComplete']);
+	}
+
+	/**
+	 * @param int $orderId
+	 */
+	public function onPaymentComplete(int $orderId)
+	{
+		//todo: find a better way to get a subscription id.
+		$order = wc_get_order($orderId);
+		$subscriptionId = $order->get_meta(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true);
+
+		$this->apiClient->activateSubscription($subscriptionId);
 	}
 }

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -39,6 +39,7 @@ class PaymentCompleteEventListener {
 			try{
 				$this->apiClient->activateSubscription($subscriptionId);
 			} catch (ApiClientException $exception) {
+				//todo: change order status?
 				eCurring_WC_Plugin::debug(
 					sprintf(
 						'Could not activate subscription, API request failed. Order id: %1$d, subscription id: %2$s, error code: %3$d, error message: %4$s.',

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Ecurring\WooEcurring\EventListener;
+
+
+use Ecurring\WooEcurring\Api\ApiClientInterface;
+
+class PaymentCompleteEventListener {
+	/**
+	 * @var ApiClientInterface
+	 */
+	protected $apiClient;
+
+	/**
+	 * @param ApiClientInterface $apiClient To make eCurring API calls.
+	 */
+	public function __construct(ApiClientInterface $apiClient){
+
+		$this->apiClient = $apiClient;
+	}
+
+	public function init()
+	{
+		add_action('woocommerce_payment_complete', [$this, 'onPaymentComplete']);
+	}
+}

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -48,15 +48,18 @@ class PaymentCompleteEventListener {
 					$subscriptionId
 				)
 			);
+			$mandateAcceptedDate = $order->get_meta(SubscriptionCrudInterface::MANDATE_ACCEPTED_DATE_FIELD);
+
 			try{
-				$this->apiClient->activateSubscription($subscriptionId);
+				$this->apiClient->activateSubscription($subscriptionId, $mandateAcceptedDate);
 			} catch (ApiClientException $exception) {
 				//todo: change order status?
 				eCurring_WC_Plugin::debug(
 					sprintf(
-						'Could not activate subscription, API request failed. Order id: %1$d, subscription id: %2$s, error code: %3$d, error message: %4$s.',
+						'Could not activate subscription, API request failed. Order id: %1$d, subscription id: %2$s, mandate accepted date: %3$s, error code: %4$d, error message: %5$s.',
 						$orderId,
 						$subscriptionId,
+						$mandateAcceptedDate,
 						$exception->getCode(),
 						$exception->getMessage()
 					)

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -2,8 +2,10 @@
 
 namespace Ecurring\WooEcurring\EventListener;
 
+use Ecurring\WooEcurring\Api\ApiClientException;
 use Ecurring\WooEcurring\Api\ApiClientInterface;
 use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;
+use eCurring_WC_Plugin;
 
 class PaymentCompleteEventListener {
 	/**
@@ -34,7 +36,19 @@ class PaymentCompleteEventListener {
 		$subscriptionId = $order->get_meta(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true);
 
 		if($subscriptionId){
-			$this->apiClient->activateSubscription($subscriptionId);
+			try{
+				$this->apiClient->activateSubscription($subscriptionId);
+			} catch (ApiClientException $exception) {
+				eCurring_WC_Plugin::debug(
+					sprintf(
+						'Could not activate subscription, API request failed. Order id: %1$d, subscription id: %2$s, error code: %3$d, error message: %4$s.',
+						$orderId,
+						$subscriptionId,
+						$exception->getCode(),
+						$exception->getMessage()
+					)
+				);
+			}
 		}
 
 	}

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Ecurring\WooEcurring\EventListener;
-
 
 use Ecurring\WooEcurring\Api\ApiClientInterface;
 use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -41,6 +41,13 @@ class PaymentCompleteEventListener {
 		$subscriptionId = $this->subscriptionCrud->getSubscriptionIdByOrder($order);
 
 		if($subscriptionId){
+			eCurring_WC_Plugin::debug(
+				sprintf(
+					'Payment completed for order %1$d. Subscription id is %1$s, trying to activate it.',
+					$order->get_id(),
+					$subscriptionId
+				)
+			);
 			try{
 				$this->apiClient->activateSubscription($subscriptionId);
 			} catch (ApiClientException $exception) {

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -19,7 +19,7 @@ class PaymentCompleteEventListener {
 		$this->apiClient = $apiClient;
 	}
 
-	public function init()
+	public function init(): void
 	{
 		add_action('woocommerce_payment_complete', [$this, 'onPaymentComplete']);
 	}

--- a/src/EventListener/PaymentCompleteEventListener.php
+++ b/src/EventListener/PaymentCompleteEventListener.php
@@ -12,13 +12,19 @@ class PaymentCompleteEventListener {
 	 * @var ApiClientInterface
 	 */
 	protected $apiClient;
+	/**
+	 * @var SubscriptionCrudInterface
+	 */
+	protected $subscriptionCrud;
 
 	/**
-	 * @param ApiClientInterface $apiClient To make eCurring API calls.
+	 * @param ApiClientInterface        $apiClient To make eCurring API calls.
+	 * @param SubscriptionCrudInterface $subscriptionCrud Service able to read subscription data.
 	 */
-	public function __construct(ApiClientInterface $apiClient){
+	public function __construct(ApiClientInterface $apiClient, SubscriptionCrudInterface $subscriptionCrud){
 
 		$this->apiClient = $apiClient;
+		$this->subscriptionCrud = $subscriptionCrud;
 	}
 
 	public function init(): void
@@ -31,9 +37,8 @@ class PaymentCompleteEventListener {
 	 */
 	public function onPaymentComplete(int $orderId)
 	{
-		//todo: find a better way to get a subscription id.
 		$order = wc_get_order($orderId);
-		$subscriptionId = $order->get_meta(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true);
+		$subscriptionId = $this->subscriptionCrud->getSubscriptionIdByOrder($order);
 
 		if($subscriptionId){
 			try{

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -19,10 +19,8 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 
 		$subscriptionOrder->update_meta_data(self::MANDATE_ACCEPTED_DATE_FIELD, date( 'Y-m-d H:i:s' ));
 		$subscriptionOrder->update_meta_data(self::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
-		$confirmationPage = $subscriptionData['data']['attributes']['confirmation_page'];
 
-		//todo: find a better way to do it.
-		$subscriptionLink = 'https://app.ecurring.com/subscriptions/'.explode('/',$confirmationPage)[5];
+		$subscriptionLink = $this->buildSubscriptionUrl($subscriptionData['links']['self']);
 		$subscriptionOrder->update_meta_data(self::ECURRING_SUBSCRIPTION_LINK_FIELD, $subscriptionLink);
 
 		$subscriptionOrder->add_order_note( sprintf(
@@ -52,5 +50,22 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 		$subscriptionId = $order->get_meta(self::ECURRING_SUBSCRIPTION_ID_FIELD, true);
 
 		return $subscriptionId ?: null;
+	}
+
+	/**
+	 * Return url of the subscription page.
+	 *
+	 * @param string $subscriptionApiUrl URL of subscription JSON API.
+	 *
+	 * @return string Url of the subscription page.
+	 */
+	protected function buildSubscriptionUrl(string $subscriptionApiUrl) {
+		$id = basename($subscriptionApiUrl);
+
+		return sprintf(
+			'https://app.ecurring.com/subscriptions/%1$s',
+			$id
+		);
+
 	}
 }

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -38,6 +38,9 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 	 * @inheritDoc
 	 */
 	public function getProductSubscriptionId( WC_Product $product) {
-		return $product->get_meta( self::ECURRING_SUBSCRIPTION_PLAN_FIELD, true );
+		$subscriptionId = $product->get_meta( self::ECURRING_SUBSCRIPTION_PLAN_FIELD, true );
+
+		//Previously plugin saved subscription id '0' for non-eCurring products.
+		return $subscriptionId ?: null;
 	}
 }

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -17,7 +17,7 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 	{
 		$subscriptionId = $subscriptionData['data']['id'];
 
-		$subscriptionOrder->update_meta_data(self::MANDATE_ACCEPTED_DATE_FIELD, date( 'Y-m-d H:i:s' ));
+		$subscriptionOrder->update_meta_data(self::MANDATE_ACCEPTED_DATE_FIELD, date( 'c' ));
 		$subscriptionOrder->update_meta_data(self::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
 
 		$subscriptionLink = $this->buildSubscriptionUrl($subscriptionData['links']['self']);

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -17,7 +17,7 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 	{
 		$subscriptionId = $subscriptionData['data']['id'];
 
-		$subscriptionOrder->update_meta_data(self::MANDATE_ACCEPTED_FIELD, date( 'Y-m-d H:i:s' ));
+		$subscriptionOrder->update_meta_data(self::MANDATE_ACCEPTED_DATE_FIELD, date( 'Y-m-d H:i:s' ));
 		$subscriptionOrder->update_meta_data(self::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
 		$confirmationPage = $subscriptionData['data']['attributes']['confirmation_page'];
 

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -43,4 +43,14 @@ class SubscriptionCrud implements SubscriptionCrudInterface {
 		//Previously plugin saved subscription id '0' for non-eCurring products.
 		return $subscriptionId ?: null;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSubscriptionIdByOrder( WC_Order $order )
+	{
+		$subscriptionId = $order->get_meta(self::ECURRING_SUBSCRIPTION_ID_FIELD, true);
+
+		return $subscriptionId ?: null;
+	}
 }

--- a/src/Subscription/SubscriptionCrud.php
+++ b/src/Subscription/SubscriptionCrud.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\Subscription;
 
 use WC_Order;

--- a/src/Subscription/SubscriptionCrudInterface.php
+++ b/src/Subscription/SubscriptionCrudInterface.php
@@ -34,4 +34,13 @@ interface SubscriptionCrudInterface {
 	 * @return string|null eCurring Subscription ID or null if no subscription exists for this product.
 	 */
 	public function getProductSubscriptionId( WC_Product $product);
+
+	/**
+	 * Get subscription id related to the given order.
+	 *
+	 * @param WC_Order $order Order to get subscription id from.
+	 *
+	 * @return string|null Subscription id or null if not exists.
+	 */
+	public function getSubscriptionIdByOrder(WC_Order $order);
 }

--- a/src/Subscription/SubscriptionCrudInterface.php
+++ b/src/Subscription/SubscriptionCrudInterface.php
@@ -10,7 +10,7 @@ use WC_Product;
  */
 interface SubscriptionCrudInterface {
 
-	const MANDATE_ACCEPTED_FIELD = 'ecurring_woocommerce_mandate_accepted_date';
+	const MANDATE_ACCEPTED_DATE_FIELD = 'ecurring_woocommerce_mandate_accepted_date';
 
 	const ECURRING_SUBSCRIPTION_ID_FIELD = '_ecurring_subscription_id';
 

--- a/src/Subscription/SubscriptionCrudInterface.php
+++ b/src/Subscription/SubscriptionCrudInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ecurring\WooEcurring\Subscription;
 
 use WC_Order;

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -71,6 +71,7 @@ class ApiClientTest extends TestCase {
 		$subscriptionId = 'subscription12345';
 		$apiKey = 'apikey098765';
 		$method = 'PATCH';
+		$mandateAcceptedDate = date('c');
 
 		$requestData = [
 			'data' => [
@@ -79,7 +80,7 @@ class ApiClientTest extends TestCase {
 				'attributes' => [
 					'status' => 'active',
 					'mandate_accepted' => true,
-					'mandate_accepted_date' => date('c')
+					'mandate_accepted_date' => $mandateAcceptedDate
 				]
 			]
 		];
@@ -109,6 +110,6 @@ class ApiClientTest extends TestCase {
 
 		$sut = new ApiClient($apiKey);
 
-		$sut->activateSubscription($subscriptionId);
+		$sut->activateSubscription($subscriptionId, $mandateAcceptedDate);
 	}
 }

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -65,4 +65,50 @@ class ApiClientTest extends TestCase {
 			$transactionWebhookUrl
 		);
 	}
+
+	public function testActivateSubscription()
+	{
+		$subscriptionId = 'subscription12345';
+		$apiKey = 'apikey098765';
+		$method = 'PATCH';
+
+		$requestData = [
+			'data' => [
+				'type' => 'subscription',
+				'id' => $subscriptionId,
+				'attributes' => [
+					'status' => 'active',
+					'mandate_accepted' => true,
+					'mandate_accepted_date' => date('c')
+				]
+			]
+		];
+
+		$requestArgs = [
+			'method'  => $method,
+			'headers' => [
+				'X-Authorization' => $apiKey,
+				'Content-Type'    => 'application/vnd.api+json',
+				'Accept'          => 'application/vnd.api+json'
+			],
+			'body' => json_encode($requestData)
+		];
+
+
+		expect('wp_remote_request')
+			->once()
+			->with(
+				'https://api.ecurring.com/subscriptions',
+				$requestArgs
+			)
+		->andReturn(
+			[
+				'body' => '{"field": "value"}'
+			]
+		);
+
+		$sut = new ApiClient($apiKey);
+
+		$sut->activateSubscription($subscriptionId);
+	}
 }

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -33,7 +33,7 @@ class ApiClientTest extends TestCase {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
 					'confirmation_sent'        => 'true',
-					'mandate_accepted'         => 'true',
+					'mandate_accepted'         => true,
 					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -32,7 +32,7 @@ class ApiClientTest extends TestCase {
 					'subscription_plan_id'     => $subscriptionPlanId,
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
-					'confirmation_sent'        => 'true',
+					'confirmation_sent'        => true,
 					'mandate_accepted'         => true,
 					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -18,7 +18,6 @@ class ApiClientTest extends TestCase {
 		$apiKey = 'someapikey135';
 		$ecurringCustomerId = 'ecurringcustomer123';
 		$subscriptionPlanId = 'subscription564';
-		$subscriptionWebhookUrl = 'http://ecurring.loc/subscription';
 		$transactionWebhookUrl = 'http://ecurring.loc/transaction';
 		$method = 'POST';
 
@@ -30,7 +29,6 @@ class ApiClientTest extends TestCase {
 				'attributes' => [
 					'customer_id'              => $ecurringCustomerId,
 					'subscription_plan_id'     => $subscriptionPlanId,
-					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
 					'confirmation_sent'        => true,
 					'metadata'                 => ['source' => 'woocommerce']
@@ -61,7 +59,6 @@ class ApiClientTest extends TestCase {
 		$sut->createSubscription(
 			$ecurringCustomerId,
 			$subscriptionPlanId,
-			$subscriptionWebhookUrl,
 			$transactionWebhookUrl
 		);
 	}

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -98,7 +98,7 @@ class ApiClientTest extends TestCase {
 		expect('wp_remote_request')
 			->once()
 			->with(
-				'https://api.ecurring.com/subscriptions',
+				sprintf('https://api.ecurring.com/subscriptions/%1$s', $subscriptionId),
 				$requestArgs
 			)
 		->andReturn(

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -33,6 +33,8 @@ class ApiClientTest extends TestCase {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
 					'confirmation_sent'        => 'true',
+					'mandate_accepted'         => 'true',
+					'mandate_accepted_date'    => date('c'),
 					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -33,9 +33,6 @@ class ApiClientTest extends TestCase {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
 					'confirmation_sent'        => true,
-					'mandate_accepted'         => true,
-					'mandate_accepted_date'    => date('c'),
-					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/tests/Unit/Api/ApiClientTest.php
+++ b/tests/Unit/Api/ApiClientTest.php
@@ -33,6 +33,7 @@ class ApiClientTest extends TestCase {
 					'subscription_webhook_url' => $subscriptionWebhookUrl,
 					'transaction_webhook_url'  => $transactionWebhookUrl,
 					'confirmation_sent'        => 'true',
+					'status'                   => 'active',
 					'metadata'                 => ['source' => 'woocommerce']
 				]
 			]

--- a/tests/Unit/EnvironmentCheckerTest.php
+++ b/tests/Unit/EnvironmentCheckerTest.php
@@ -4,9 +4,12 @@ namespace eCurring\WooEcurringTests\Unit;
 
 use Ecurring\WooEcurring\EnvironmentChecker;
 use eCurring\WooEcurringTests\TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use function Brain\Monkey\Functions\expect;
 
 class EnvironmentCheckerTest extends TestCase {
+
+	use MockeryPHPUnitIntegration; //to count Mockery expectations properly as assertions
 
 	/**
 	 * Test if isMolliePluginActive functions correctly checks for that plugin and returns correct result.

--- a/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
+++ b/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
@@ -45,7 +45,7 @@ class MolliePaymentEventListenerTest extends TestCase {
 		$sut->init();
 	}
 
-	public function testOnMollieSubscription()
+	public function testOnMolliePaymentCreated()
 	{
 		/** @var ApiClient&MockObject $apiClientMock */
 		$apiClientMock = $this->createMock(ApiClient::class);

--- a/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
+++ b/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
@@ -35,7 +35,12 @@ class MolliePaymentEventListenerTest extends TestCase {
 
 		expect('add_action')
 		->once()
-		->with('mollie-payments-for-woocommerce_payment_created', [$sut, 'onMolliePaymentCreated']);
+		->with(
+			'mollie-payments-for-woocommerce_payment_created',
+			[$sut, 'onMolliePaymentCreated'],
+			10,
+			2
+		);
 
 		$sut->init();
 	}

--- a/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
+++ b/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
@@ -66,21 +66,13 @@ class MolliePaymentEventListenerTest extends TestCase {
 			);
 
 		$productMock = $this->createMock( WC_Product::class);
-		$ecurringSubscriptionPlan = 'somesubscriptionplan';
-		$productMock->expects($this->once())
-			->method('get_meta')
-			->with('_ecurring_subscription_plan', true)
-			->willReturn($ecurringSubscriptionPlan);
 
-		$productMock->expects($this->once())
-			->method('meta_exists')
-			->with('_ecurring_subscription_plan')
-			->willReturn(true);
+		$ecurringSubscriptionId = 'ecurringsubscriptionid3463';
 
-		$productMock->expects($this->once())
-			->method('get_meta')
-			->with('_ecurring_subscription_plan')
-			->willReturn($ecurringSubscriptionPlan);
+		$subscriptionCrudMock->expects($this->once())
+			->method('getProductSubscriptionId')
+			->with($productMock)
+			->willReturn($ecurringSubscriptionId);
 
 		$orderItemProductMock->expects($this->once())
 			->method('get_product')
@@ -101,7 +93,7 @@ class MolliePaymentEventListenerTest extends TestCase {
 			->method('createSubscription')
 			->with(
 				$ecurringCustomerId,
-				$ecurringSubscriptionPlan,
+				$ecurringSubscriptionId,
 				'',
 				''
 			)

--- a/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
+++ b/tests/Unit/EventListener/MolliePaymentEventListenerTest.php
@@ -99,7 +99,6 @@ class MolliePaymentEventListenerTest extends TestCase {
 			->with(
 				$ecurringCustomerId,
 				$ecurringSubscriptionId,
-				'',
 				''
 			)
 			->willReturn([]);

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -7,6 +7,7 @@ namespace eCurring\WooEcurringTests\Unit\EventListener;
 use Ecurring\WooEcurring\Api\ApiClientInterface;
 use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;
 use eCurring\WooEcurringTests\TestCase;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Order;
@@ -43,6 +44,8 @@ class PaymentCompleteEventListenerTest extends TestCase {
 		$subscriptionId = 'subscription321';
 
 		$wcOrderMock = $this->createMock( WC_Order::class);
+		$wcOrderMock->method('get_id')
+			->willReturn($orderId);
 
 		expect('wc_get_order')
 			->once()
@@ -60,6 +63,10 @@ class PaymentCompleteEventListenerTest extends TestCase {
 			->method('getSubscriptionIdByOrder')
 			->with($wcOrderMock)
 			->willReturn($subscriptionId);
+
+		//Prevent calling static eCurring_WC_Plugin::debug() method.
+		$pluginMock = Mockery::mock('alias:eCurring_WC_Plugin');
+		$pluginMock->shouldReceive('debug');
 
 		$sut = new PaymentCompleteEventListener($apiClientMock, $subscriptionCrudMock);
 

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -5,9 +5,11 @@ namespace eCurring\WooEcurringTests\Unit\EventListener;
 
 
 use Ecurring\WooEcurring\Api\ApiClientInterface;
+use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;
 use eCurring\WooEcurringTests\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+use WC_Order;
 use function Brain\Monkey\Functions\expect;
 use Ecurring\WooEcurring\EventListener\PaymentCompleteEventListener;
 
@@ -35,6 +37,18 @@ class PaymentCompleteEventListenerTest extends TestCase {
 	public function testOnPaymentComplete()
 	{
 		$orderId = 123;
+		$subscriptionId = 'subscription321';
+
+		$wcOrderMock = $this->createMock( WC_Order::class);
+		$wcOrderMock->method('get_meta')
+			->with(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true)
+			->willReturn($subscriptionId);
+
+		expect('wc_get_order')
+			->once()
+			->with($orderId)
+			->andReturn($wcOrderMock);
+
 		/** @var ApiClientInterface&MockObject $apiClientMock */
 		$apiClientMock = $this->createMock(ApiClientInterface::class);
 		$apiClientMock->expects($this->once())

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -31,4 +31,16 @@ class PaymentCompleteEventListenerTest extends TestCase {
 
 		$sut->init();
 	}
+
+	public function testOnPaymentComplete()
+	{
+		$orderId = 123;
+		/** @var ApiClientInterface&MockObject $apiClientMock */
+		$apiClientMock = $this->createMock(ApiClientInterface::class);
+		$apiClientMock->expects($this->once())
+			->method('activateSubscription');
+		$sut = new PaymentCompleteEventListener($apiClientMock);
+
+		$sut->onPaymentComplete($orderId);
+	}
 }

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -22,7 +22,10 @@ class PaymentCompleteEventListenerTest extends TestCase {
 		/** @var ApiClientInterface&MockObject $apiClientMock */
 		$apiClientMock = $this->createMock(ApiClientInterface::class);
 
-		$sut = new PaymentCompleteEventListener($apiClientMock);
+		/** @var SubscriptionCrudInterface&MockObject $subscriptionCrudMock */
+		$subscriptionCrudMock = $this->createMock(SubscriptionCrudInterface::class);
+
+		$sut = new PaymentCompleteEventListener($apiClientMock, $subscriptionCrudMock);
 
 		expect('add_action')
 			->once()
@@ -40,9 +43,6 @@ class PaymentCompleteEventListenerTest extends TestCase {
 		$subscriptionId = 'subscription321';
 
 		$wcOrderMock = $this->createMock( WC_Order::class);
-		$wcOrderMock->method('get_meta')
-			->with(SubscriptionCrudInterface::ECURRING_SUBSCRIPTION_ID_FIELD, true)
-			->willReturn($subscriptionId);
 
 		expect('wc_get_order')
 			->once()
@@ -53,7 +53,15 @@ class PaymentCompleteEventListenerTest extends TestCase {
 		$apiClientMock = $this->createMock(ApiClientInterface::class);
 		$apiClientMock->expects($this->once())
 			->method('activateSubscription');
-		$sut = new PaymentCompleteEventListener($apiClientMock);
+
+		/** @var SubscriptionCrudInterface&MockObject $subscriptionCrudMock */
+		$subscriptionCrudMock = $this->createMock(SubscriptionCrudInterface::class);
+		$subscriptionCrudMock->expects($this->once())
+			->method('getSubscriptionIdByOrder')
+			->with($wcOrderMock)
+			->willReturn($subscriptionId);
+
+		$sut = new PaymentCompleteEventListener($apiClientMock, $subscriptionCrudMock);
 
 		$sut->onPaymentComplete($orderId);
 	}

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace eCurring\WooEcurringTests\Unit\EventListener;
+
+
+use Ecurring\WooEcurring\Api\ApiClientInterface;
+use eCurring\WooEcurringTests\TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+use function Brain\Monkey\Functions\expect;
+use Ecurring\WooEcurring\EventListener\PaymentCompleteEventListener;
+
+class PaymentCompleteEventListenerTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;	//to properly count Mockery expectations as assertions.
+
+	public function testInit(){
+
+		/** @var ApiClientInterface&MockObject $apiClientMock */
+		$apiClientMock = $this->createMock(ApiClientInterface::class);
+
+		$sut = new PaymentCompleteEventListener($apiClientMock);
+
+		expect('add_action')
+			->once()
+			->with(
+				'woocommerce_payment_complete',
+				[$sut, 'onPaymentComplete']
+			);
+
+		$sut->init();
+	}
+}

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -42,10 +42,15 @@ class PaymentCompleteEventListenerTest extends TestCase {
 	{
 		$orderId = 123;
 		$subscriptionId = 'subscription321';
+		$mandateAcceptedDate = date('c');
 
 		$wcOrderMock = $this->createMock( WC_Order::class);
 		$wcOrderMock->method('get_id')
 			->willReturn($orderId);
+
+		$wcOrderMock->method('get_meta')
+			->with(SubscriptionCrudInterface::MANDATE_ACCEPTED_DATE_FIELD)
+			->willReturn($mandateAcceptedDate);
 
 		expect('wc_get_order')
 			->once()
@@ -69,6 +74,7 @@ class PaymentCompleteEventListenerTest extends TestCase {
 		$pluginMock->shouldReceive('debug');
 
 		$sut = new PaymentCompleteEventListener($apiClientMock, $subscriptionCrudMock);
+
 
 		$sut->onPaymentComplete($orderId);
 	}

--- a/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompleteEventListenerTest.php
@@ -40,6 +40,11 @@ class PaymentCompleteEventListenerTest extends TestCase {
 
 	public function testOnPaymentComplete()
 	{
+		//Prevent calling static eCurring_WC_Plugin::debug() method.
+		$pluginMock = Mockery::mock('alias:eCurring_WC_Plugin');
+		$pluginMock->shouldReceive('debug');
+
+
 		$orderId = 123;
 		$subscriptionId = 'subscription321';
 		$mandateAcceptedDate = date('c');
@@ -68,10 +73,6 @@ class PaymentCompleteEventListenerTest extends TestCase {
 			->method('getSubscriptionIdByOrder')
 			->with($wcOrderMock)
 			->willReturn($subscriptionId);
-
-		//Prevent calling static eCurring_WC_Plugin::debug() method.
-		$pluginMock = Mockery::mock('alias:eCurring_WC_Plugin');
-		$pluginMock->shouldReceive('debug');
 
 		$sut = new PaymentCompleteEventListener($apiClientMock, $subscriptionCrudMock);
 

--- a/tests/Unit/Subscription/SubscriptionCrudTest.php
+++ b/tests/Unit/Subscription/SubscriptionCrudTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace eCurring\WooEcurringTests\Unit\Subscription;
+
+use Ecurring\WooEcurring\Subscription\SubscriptionCrud;
+use eCurring\WooEcurringTests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Order;
+use function Brain\Monkey\Functions\when;
+
+class SubscriptionCrudTest extends TestCase {
+
+	/**
+	 * @dataProvider subscriptionDataProvider
+	 */
+	public function testSaveSubscription(array $subscriptionData, $subscriptionId)
+	{
+		$mandateAcceptedDate = '2020-01-01';
+
+		/** @var WC_Order&MockObject $wcOrderMock */
+		$wcOrderMock = $this->createMock( WC_Order::class);
+
+		$wcOrderMock->expects($this->at(0))
+			->method('update_meta_data')
+			->with(SubscriptionCrud::MANDATE_ACCEPTED_DATE_FIELD, $mandateAcceptedDate);
+
+		$wcOrderMock->expects($this->at(1))
+			->method('update_meta_data')
+			->with(SubscriptionCrud::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
+
+		$wcOrderMock->expects($this->once())
+			->method('save');
+
+		when('date')->justReturn($mandateAcceptedDate);
+		when('__')->returnArg();
+
+		$wcOrderMock->expects($this->once())
+			->method('add_order_note')
+			->with($this->stringContains($subscriptionId));
+
+		$sut = new SubscriptionCrud();
+		$sut->saveSubscription($subscriptionData, $wcOrderMock);
+	}
+
+	/**
+	 * Subscription data example is taken from the eCurring documentation.
+	 *
+	 * @see https://docs.ecurring.com/subscriptions/get
+	 */
+	public function subscriptionDataProvider() {
+		$subscriptionId = '1';
+
+		$mandateAcceptedDate = '2020-01-01';
+
+		return [
+			[
+				[
+					"links" => [
+						"self" => "https=>//api.ecurring.com/subscriptions/1"
+					],
+					"data"  => [
+						"type"          => "subscription",
+						"id"            => $subscriptionId,
+						"links"         => [
+							"self" => "https=>//api.ecurring.com/subscriptions/1"
+						],
+						"attributes"    => [
+							"mandate_code"             => "ECUR-1",
+							"mandate_accepted"         => true,
+							"mandate_accepted_date"    => $mandateAcceptedDate,
+							"start_date"               => "2017-21-11T22=>11=>57+01=>00",
+							"status"                   => "active",
+							"cancel_date"              => null,
+							"resume_date"              => null,
+							"confirmation_page"        => "https=>//app.ecurring.com/mandate/accept/1/ECUR-1",
+							"confirmation_sent"        => false,
+							"subscription_webhook_url" => null,
+							"transaction_webhook_url"  => null,
+							"success_redirect_url"     => null,
+							"metadata"                 => [],
+							"archived"                 => false,
+							"created_at"               => "2017-02-01T11=>21=>09+01=>00",
+							"updated_at"               => "2017-02-11T00=>00=>00+01=>00"
+						],
+						"relationships" => [
+							"subscription-plan" => [
+								"data" => [
+									"type" => "subscription-plan",
+									"id"   => "1"
+								]
+							],
+							"customer"          => [
+								"data" => [
+									"type" => "customer",
+									"id"   => "1"
+								]
+							],
+							"transactions"      => [
+								"links" => [
+									"related" => "https=>//api.ecurring.com/subscriptions/1/transactions"
+								],
+								"data"  => [
+									[
+										"type" => "transaction",
+										"id"   => "02f3c67b-1e1a-4692-8826-14f17f9b2c61"
+									]
+								]
+							]
+						]
+					]
+				],
+				$subscriptionId
+			]
+		];
+	}
+}

--- a/tests/Unit/Subscription/SubscriptionCrudTest.php
+++ b/tests/Unit/Subscription/SubscriptionCrudTest.php
@@ -56,31 +56,31 @@ class SubscriptionCrudTest extends TestCase {
 			[
 				[
 					"links" => [
-						"self" => "https=>//api.ecurring.com/subscriptions/1"
+						"self" => "https://api.ecurring.com/subscriptions/1"
 					],
 					"data"  => [
 						"type"          => "subscription",
 						"id"            => $subscriptionId,
 						"links"         => [
-							"self" => "https=>//api.ecurring.com/subscriptions/1"
+							"self" => "https://api.ecurring.com/subscriptions/1"
 						],
 						"attributes"    => [
 							"mandate_code"             => "ECUR-1",
 							"mandate_accepted"         => true,
 							"mandate_accepted_date"    => $mandateAcceptedDate,
-							"start_date"               => "2017-21-11T22=>11=>57+01=>00",
+							"start_date"               => "2017-21-11T22:11:57+01:00",
 							"status"                   => "active",
 							"cancel_date"              => null,
 							"resume_date"              => null,
-							"confirmation_page"        => "https=>//app.ecurring.com/mandate/accept/1/ECUR-1",
+							"confirmation_page"        => "https://app.ecurring.com/mandate/accept/1/ECUR-1",
 							"confirmation_sent"        => false,
 							"subscription_webhook_url" => null,
 							"transaction_webhook_url"  => null,
 							"success_redirect_url"     => null,
 							"metadata"                 => [],
 							"archived"                 => false,
-							"created_at"               => "2017-02-01T11=>21=>09+01=>00",
-							"updated_at"               => "2017-02-11T00=>00=>00+01=>00"
+							"created_at"               => "2017-02-01T11:21:09+01:00",
+							"updated_at"               => "2017-02-11T00:00:00+01:00"
 						],
 						"relationships" => [
 							"subscription-plan" => [
@@ -97,7 +97,7 @@ class SubscriptionCrudTest extends TestCase {
 							],
 							"transactions"      => [
 								"links" => [
-									"related" => "https=>//api.ecurring.com/subscriptions/1/transactions"
+									"related" => "https://api.ecurring.com/subscriptions/1/transactions"
 								],
 								"data"  => [
 									[

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -30,6 +30,18 @@ class WC_Order
     public function get_meta()
     {
     }
+
+    public function update_meta_data()
+    {
+    }
+
+    public function add_order_note()
+    {
+    }
+
+    public function save()
+    {
+    }
 }
 
 if(! class_exists(WC_Order_Item::class))

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -19,6 +19,10 @@ class WC_Order
     {
     	return [];
     }
+
+    public function get_meta()
+    {
+    }
 }
 
 if(! class_exists(WC_Order_Item::class))

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -13,6 +13,10 @@ class WC_Payment_Gateway
 
 class WC_Order
 {
+	public function get_id()
+	{
+	}
+
     public function get_customer_id()
     {
         return 1;


### PR DESCRIPTION
Addresses [ECUR-48](https://inpsyde.atlassian.net/browse/ECUR-48).

Listen to the `*_payment_created` action, send a request to the `eCurring` API to create a new subscription. If the subscription created successfully, save it to the database as it worked before. Then, on `woocommerce_payment_complete`, make subscription active on `eCurring` side.

Also, the minimal `PHP` version increased to `7.2`.