### PR TITLE
Filter no recurring payment methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^7.1",
-        "brain/monkey": "^2.4"
+        "brain/monkey": "^2.4",
+        "antecedent/patchwork": " ^2.1"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc25ac95d446b87bd0155f2cf3aed39c",
+    "content-hash": "cd5ab2eeb9eb561220ce371dda9d577d",
     "packages": [],
     "packages-dev": [
         {

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -1,8 +1,9 @@
 <?php
 
-// Require Webhook functions
+
 use Ecurring\WooEcurring\PaymentGatewaysFilter\WhitelistedRecurringPaymentGatewaysFilter;
 
+// Require Webhook functions
 require_once dirname(dirname(dirname(__FILE__))) . '/webhook_functions.php';
 
 class eCurring_WC_Plugin

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -752,8 +752,6 @@ class eCurring_WC_Plugin
 							unset( $gateway_list[ $gatewayId ] );
 						}
 					}
-				} else {
-					unset( $gateway_list['ecurring_wc_gateway_ecurring'] );
 				}
 			}
 		}

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -765,7 +765,11 @@ class eCurring_WC_Plugin
 			$items = WC()->cart->get_cart();
 			foreach ( $items as $item ) {
 				$product = $item['data'];
-				if ( $product instanceof WC_Product && $product->meta_exists('_ecurring_subscription_plan') ) {
+
+				// we need to use !empty check instead of just meta_exists because
+                // previously this field was added to non-eCurring products
+                // with value '0'.
+				if ( $product instanceof WC_Product && ! empty($product->get_meta('_ecurring_subscription_plan', true)) ) {
 					return true;
 				}
 			}

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -738,9 +738,9 @@ class eCurring_WC_Plugin
 	 * Left only eCurring payment gateway if there is eCurring product, and hide payment gateway div.
 	 * Otherwise just exclude eCurring payment gateway.
 	 *
-	 * @param WC_Payment_Gateway[] $gateway_list
+	 * @param WC_Payment_Gateway[] $gateway_list Payment gateways from WooCommerce to filter.
 	 *
-	 * @return mixed
+	 * @return WC_Payment_Gateway[] Filtered gateways list.
 	 */
 	public static function eCurringFilterGateways($gateway_list) {
 		if ( isset( WC()->cart ) ) {

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -743,16 +743,13 @@ class eCurring_WC_Plugin
 	 * @return WC_Payment_Gateway[] Filtered gateways list.
 	 */
 	public static function eCurringFilterGateways($gateway_list) {
-		if ( isset( WC()->cart ) ) {
-			$items = WC()->cart->get_cart();
-			foreach ( $items as $item ) {
-				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
-					foreach ( $gateway_list as $gatewayId => $gateway ) {
-						if ( ! self::isMolliePaymentGateway($gateway) || ! $gateway->supports('subscriptions')) {
-							unset( $gateway_list[ $gatewayId ] );
-						}
-					}
-				}
+	    if(! self::eCurringSubscriptionIsInCart()) {
+	        return $gateway_list;
+        }
+
+		foreach ( $gateway_list as $gatewayId => $gateway ) {
+			if ( ! self::isMolliePaymentGateway($gateway) || ! $gateway->supports('subscriptions')) {
+				unset( $gateway_list[ $gatewayId ] );
 			}
 		}
 

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -761,12 +761,12 @@ class eCurring_WC_Plugin
 		if ( isset( WC()->cart ) ) {
 			$items = WC()->cart->get_cart();
 			foreach ( $items as $item ) {
-				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
+				$product = $item['data'];
+				if ( $product instanceof WC_Product && $product->meta_exists('_ecurring_subscription_plan') ) {
 					return true;
 				}
 			}
 		}
-
 		return false;
     }
 

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -738,7 +738,7 @@ class eCurring_WC_Plugin
 	 * Left only eCurring payment gateway if there is eCurring product, and hide payment gateway div.
 	 * Otherwise just exclude eCurring payment gateway.
 	 *
-	 * @param $gateway_list
+	 * @param WC_Payment_Gateway[] $gateway_list
 	 *
 	 * @return mixed
 	 */

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -759,6 +759,24 @@ class eCurring_WC_Plugin
 		return $gateway_list;
 	}
 
+	/**
+     * Check if cart contains at least one eCurring subscription product.
+     *
+	 * @return bool Is subscription found.
+	 */
+	public static function eCurringSubscriptionIsInCart() {
+		if ( isset( WC()->cart ) ) {
+			$items = WC()->cart->get_cart();
+			foreach ( $items as $item ) {
+				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+    }
+
     /**
      * Check if provided payment gateway instance was added by Mollie.
      *

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -747,13 +747,9 @@ class eCurring_WC_Plugin
 	        return $gateway_list;
         }
 
-		foreach ( $gateway_list as $gatewayId => $gateway ) {
-			if ( ! self::isMolliePaymentGateway($gateway) || ! $gateway->supports('subscriptions')) {
-				unset( $gateway_list[ $gatewayId ] );
-			}
-		}
-
-		return $gateway_list;
+		return array_filter($gateway_list, function($gateway){
+		    return self::isMolliePaymentGateway($gateway) && $gateway->supports('subscriptions');
+        });
 	}
 
 	/**

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -749,7 +749,7 @@ class eCurring_WC_Plugin
 	        return $gatewayList;
         }
 
-	    $mollieGateways = self::getMollieGatewaysClassNames();
+	    $mollieGateways = apply_filters('mollie-payments-for-woocommerce_retrieve_payment_gateways', []);
 	    $mollieRecurringGatewaysFilter = new WhitelistedRecurringPaymentGatewaysFilter($mollieGateways);
 	    return $mollieRecurringGatewaysFilter->filter($gatewayList);
 	}
@@ -770,25 +770,6 @@ class eCurring_WC_Plugin
 			}
 		}
 		return false;
-    }
-
-
-    /**
-     * Get list of payment gateways class names added by Mollie Payments for WooCommerce plugin.
-     *
-     * This method has to be static for now because it called from another static method.
-     *
-     * @return array
-     */
-    protected static function getMollieGatewaysClassNames()
-    {
-        if (class_exists(Mollie_WC_Plugin::class) &&
-            isset(Mollie_WC_Plugin::$GATEWAYS) &&
-            is_array(Mollie_WC_Plugin::$GATEWAYS)) {
-            return Mollie_WC_Plugin::$GATEWAYS;
-        }
-
-        return [];
     }
 
 	/**

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -1,6 +1,8 @@
 <?php
 
 // Require Webhook functions
+use Ecurring\WooEcurring\PaymentGatewaysFilter\WhitelistedRecurringPaymentGatewaysFilter;
+
 require_once dirname(dirname(dirname(__FILE__))) . '/webhook_functions.php';
 
 class eCurring_WC_Plugin
@@ -738,18 +740,18 @@ class eCurring_WC_Plugin
 	 * Left only eCurring payment gateway if there is eCurring product, and hide payment gateway div.
 	 * Otherwise just exclude eCurring payment gateway.
 	 *
-	 * @param WC_Payment_Gateway[] $gateway_list Payment gateways from WooCommerce to filter.
+	 * @param WC_Payment_Gateway[] $gatewayList Payment gateways from WooCommerce to filter.
 	 *
 	 * @return WC_Payment_Gateway[] Filtered gateways list.
 	 */
-	public static function eCurringFilterGateways($gateway_list) {
+	public static function eCurringFilterGateways($gatewayList) {
 	    if(! self::eCurringSubscriptionIsInCart()) {
-	        return $gateway_list;
+	        return $gatewayList;
         }
 
-		return array_filter($gateway_list, function($gateway){
-		    return self::isMolliePaymentGateway($gateway) && $gateway->supports('subscriptions');
-        });
+	    $mollieGateways = self::getMollieGatewaysClassNames();
+	    $mollieRecurringGatewaysFilter = new WhitelistedRecurringPaymentGatewaysFilter($mollieGateways);
+	    return $mollieRecurringGatewaysFilter->filter($gatewayList);
 	}
 
 	/**
@@ -768,18 +770,6 @@ class eCurring_WC_Plugin
 			}
 		}
 		return false;
-    }
-
-    /**
-     * Check if provided payment gateway instance was added by Mollie.
-     *
-     * @param WC_Payment_Gateway $gateway
-     *
-     * @return bool Check result.
-     */
-	protected static function isMolliePaymentGateway(WC_Payment_Gateway $gateway)
-    {
-        return in_array(get_class($gateway), self::getMollieGatewaysClassNames(), true);
     }
 
 

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -748,7 +748,7 @@ class eCurring_WC_Plugin
 			foreach ( $items as $item ) {
 				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
 					foreach ( $gateway_list as $gateway => $data ) {
-						if ( $gateway != 'ecurring_wc_gateway_ecurring' && ! self::isMolliePaymentGateway($data)) {
+						if ( ! self::isMolliePaymentGateway($data)) {
 							unset( $gateway_list[ $gateway ] );
 						}
 					}

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -748,7 +748,7 @@ class eCurring_WC_Plugin
 			foreach ( $items as $item ) {
 				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
 					foreach ( $gateway_list as $gatewayId => $gateway ) {
-						if ( ! self::isMolliePaymentGateway($gateway)) {
+						if ( ! self::isMolliePaymentGateway($gateway) || ! $gateway->supports('subscriptions')) {
 							unset( $gateway_list[ $gatewayId ] );
 						}
 					}

--- a/includes/ecurring/wc/plugin.php
+++ b/includes/ecurring/wc/plugin.php
@@ -747,9 +747,9 @@ class eCurring_WC_Plugin
 			$items = WC()->cart->get_cart();
 			foreach ( $items as $item ) {
 				if ( get_post_meta( $item['product_id'], '_ecurring_subscription_plan', true ) ) {
-					foreach ( $gateway_list as $gateway => $data ) {
-						if ( ! self::isMolliePaymentGateway($data)) {
-							unset( $gateway_list[ $gateway ] );
+					foreach ( $gateway_list as $gatewayId => $gateway ) {
+						if ( ! self::isMolliePaymentGateway($gateway)) {
+							unset( $gateway_list[ $gatewayId ] );
 						}
 					}
 				} else {

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+  "redefinable-internals": [
+    "get_class"
+  ]
+}

--- a/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
+++ b/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ecurring\WooEcurring\PaymentGatewaysFilter;
 

--- a/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
+++ b/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Ecurring\WooEcurring\PaymentGatewaysFilter;
+
+use WC_Payment_Gateway;
+
+interface PaymentGatewaysFilterInterface {
+
+	/**
+	 * Filter arrays by some criteria.
+	 *
+	 * @param WC_Payment_Gateway[] $gateways Initial gateways list.
+	 *
+	 * @return WC_Payment_Gateway[] Filtered gateways list.
+	 */
+	public function filter(array $gateways): array;
+}

--- a/src/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilter.php
+++ b/src/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilter.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Ecurring\WooEcurring\PaymentGatewaysFilter;
+
+use WC_Payment_Gateway;
+
+/**
+ * Filter WooCommerce payment gateways, return only whitelisted and supporting 'subscription' ones.
+ */
+class WhitelistedRecurringPaymentGatewaysFilter implements PaymentGatewaysFilterInterface {
+
+	/**
+	 * @var string[] List of allowed payment gateway classes.
+	 */
+	protected $whiteList;
+
+	/**
+	 * @param string[] $whiteList White list of payment gateway class names.
+	 */
+	public function __construct(array $whiteList)
+	{
+		$this->whiteList = $whiteList;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function filter( array $gateways ): array {
+		return array_filter($gateways, function(WC_Payment_Gateway $gateway){
+			return $this->isGatewayClassWhitelisted($gateway) && $gateway->supports('subscription');
+		});
+	}
+
+	/**
+	 * Check if gateway is in the white list.
+	 *
+	 * @param WC_Payment_Gateway $gateway Gateway to check.
+	 *
+	 * @return bool
+	 */
+	protected function isGatewayClassWhitelisted( WC_Payment_Gateway $gateway ) {
+		return in_array(get_class($gateway), $this->whiteList, true);
+	}
+}

--- a/src/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilter.php
+++ b/src/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilter.php
@@ -6,7 +6,7 @@ namespace Ecurring\WooEcurring\PaymentGatewaysFilter;
 use WC_Payment_Gateway;
 
 /**
- * Filter WooCommerce payment gateways, return only whitelisted and supporting 'subscription' ones.
+ * Filter WooCommerce payment gateways, return only whitelisted and supporting 'subscriptions' ones.
  */
 class WhitelistedRecurringPaymentGatewaysFilter implements PaymentGatewaysFilterInterface {
 
@@ -28,7 +28,7 @@ class WhitelistedRecurringPaymentGatewaysFilter implements PaymentGatewaysFilter
 	 */
 	public function filter( array $gateways ): array {
 		return array_filter($gateways, function(WC_Payment_Gateway $gateway){
-			return $this->isGatewayClassWhitelisted($gateway) && $gateway->supports('subscription');
+			return $this->isGatewayClassWhitelisted($gateway) && $gateway->supports('subscriptions');
 		});
 	}
 

--- a/tests/Unit/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilterTest.php
+++ b/tests/Unit/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace eCurring\WooEcurringTests\Unit\PaymentGatewaysFilter;
+
+use Ecurring\WooEcurring\PaymentGatewaysFilter\WhitelistedRecurringPaymentGatewaysFilter;
+use eCurring\WooEcurringTests\TestCase;
+use WC_Payment_Gateway;
+use function Patchwork\redefine;
+
+class WhitelistedRecurringPaymentGatewaysFilterTest extends TestCase {
+
+	/**
+	 * @dataProvider filterTestDataProvider
+	 */
+	public function testFilter(
+		array $whitelistedClasses,
+		array $gatewaysToFilter,
+		array $expectedResult
+	) {
+
+		//Cannot use `expect()` from brain/monkey package because of endless loop is starting after calling `andReturn()`
+		redefine('get_class', function($item){
+			if(! is_object($item)){
+				return false;
+			}
+
+			return $item->whitelisted ? 'Some\Whitelisted\Class\Name' : 'Some\Not\Whitelisted\Class\Name';
+		});
+
+		$sut = new WhitelistedRecurringPaymentGatewaysFilter($whitelistedClasses);
+		$filtered = $sut->filter($gatewaysToFilter);
+
+		$this->assertSame($expectedResult, array_values($filtered));
+	}
+
+	public function filterTestDataProvider() {
+		$nonRecurringGateway = $this->createMock( WC_Payment_Gateway::class );
+		$nonRecurringGateway->method( 'supports' )
+		                    ->with( 'subscriptions' )
+		                    ->willReturn( false );
+
+		$nonRecurringGateway->whitelisted = true;
+
+
+		$recurringGateway = $this->createMock( WC_Payment_Gateway::class );
+		$recurringGateway->method( 'supports' )
+		                 ->with( 'subscriptions' )
+		                 ->willReturn( true );
+
+		$recurringGateway->whitelisted = false;
+
+		$recurringWhitelistedGateway = $this->createMock( WC_Payment_Gateway::class );
+		$recurringWhitelistedGateway->method( 'supports' )
+		                            ->with( 'subscriptions' )
+		                            ->willReturn( true );
+
+		$recurringWhitelistedGateway->whitelisted = true;
+
+
+
+		$whitelist = ['Some\Whitelisted\Class\Name'];
+
+		return [
+			[
+				[],
+				[],
+				[]
+			],
+			[
+				$whitelist,
+				[ $nonRecurringGateway, $recurringGateway, $recurringWhitelistedGateway ],
+				[ $recurringWhitelistedGateway ]
+			]
+		];
+	}
+}

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -6,6 +6,9 @@ if (!defined('WC_VERSION')) {
 
 class WC_Payment_Gateway
 {
+	public function supports()
+	{
+	}
 }
 
 class WC_Order


### PR DESCRIPTION
Addresses [ECUR-51](https://inpsyde.atlassian.net/browse/ECUR-51).

Filter available payment methods on checkout if `eCurring` product is in the cart. Only left payment methods provided by `Mollie Subscriptions for Woocommerce` plugin and supporting `subscriptions`.