### PR TITLE
Fix warning caused by filemtime() function

### DIFF
--- a/.psalm/autoloader.php
+++ b/.psalm/autoloader.php
@@ -1,4 +1,5 @@
 <?php
+
 if (defined('ABSPATH')) {
     return;
 }
@@ -6,6 +7,10 @@ if (defined('ABSPATH')) {
 define('PROJECT_DIR', dirname(__DIR__));
 define('ABSPATH', PROJECT_DIR . '/vendor/wordpress/wordpress/');
 define('WPINC', 'wp-includes');
+
+if (! defined('WOOECUR_PLUGIN_FILE')) {
+    define('WOOECUR_PLUGIN_FILE', '');
+}
 
 require_once ABSPATH . WPINC . '/plugin.php';
 require_once ABSPATH . WPINC . '/load.php';

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -32,20 +32,20 @@ class Assets
                     return;
                 }
 
-                $scriptFilePath = eCurring_WC_Plugin::getPluginUrl('assets/js/admin-subscriptions.js');
+                $scriptFileUrl = eCurring_WC_Plugin::getPluginUrl('assets/js/admin-subscriptions.js');
 
                 wp_enqueue_script(
                     'ecurring_admin_subscriptions',
-                    $scriptFilePath,
+                    $scriptFileUrl,
                     ['jquery'],
                     (string) filemtime($this->pluginAssetsPath . 'js/admin-subscriptions.js')
                 );
 
-                $stylesFilePath = eCurring_WC_Plugin::getPluginUrl('assets/css/admin-subscriptions.css');
+                $stylesFileUrl = eCurring_WC_Plugin::getPluginUrl('assets/css/admin-subscriptions.css');
 
                 wp_enqueue_style(
                     'ecurring_admin_subscriptions',
-                    $stylesFilePath,
+                    $stylesFileUrl,
                     [],
                     (string) filemtime($this->pluginAssetsPath . 'css/admin-subscriptions.css')
                 );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -9,17 +9,24 @@ use WP_Screen;
 
 class Assets
 {
+    /**
+     * @var string
+     */
+    protected $pluginAssetsPath = '';
+
     public function init(): void
     {
         $this->enqueueAdminScripts();
         $this->enqueueFrontScripts();
+
+        $this->pluginAssetsPath = plugin_dir_path(WOOECUR_PLUGIN_FILE) . 'assets/';
     }
 
     protected function enqueueAdminScripts(): void
     {
         add_action(
             'admin_enqueue_scripts',
-            static function () {
+            function () {
                 $screen = get_current_screen();
                 if ($screen instanceof WP_Screen && $screen->id !== 'esubscriptions') {
                     return;
@@ -31,7 +38,7 @@ class Assets
                     'ecurring_admin_subscriptions',
                     $scriptFilePath,
                     ['jquery'],
-                    (string) filemtime($scriptFilePath)
+                    (string) filemtime($this->pluginAssetsPath . 'js/admin-subscriptions.js')
                 );
 
                 $stylesFilePath = eCurring_WC_Plugin::getPluginUrl('assets/css/admin-subscriptions.css');
@@ -40,7 +47,7 @@ class Assets
                     'ecurring_admin_subscriptions',
                     $stylesFilePath,
                     [],
-                    (string) filemtime($stylesFilePath)
+                    (string) filemtime($this->pluginAssetsPath . 'css/admin-subscriptions.css')
                 );
             }
         );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -57,11 +57,11 @@ class Assets
     {
         add_action(
             'wp_enqueue_scripts',
-            static function () {
-                $scriptFilePath = eCurring_WC_Plugin::getPluginUrl('assets/js/customer-subscriptions.js');
+            function () {
+                $scriptFileUrl = eCurring_WC_Plugin::getPluginUrl('assets/js/customer-subscriptions.js');
                 wp_enqueue_script(
                     'ecurring_customer_subscriptions',
-                    $scriptFilePath,
+                    $scriptFileUrl,
                     ['jquery'],
                     (string) filemtime($scriptFilePath)
                 );
@@ -74,11 +74,11 @@ class Assets
                     ]
                 );
 
-                $stylesFilePath = eCurring_WC_Plugin::getPluginUrl('assets/css/customer-subscriptions.css');
+                $stylesFileUrl = eCurring_WC_Plugin::getPluginUrl('assets/css/customer-subscriptions.css');
 
                 wp_enqueue_style(
                     'ecurring_customer_subscriptions',
-                    $stylesFilePath,
+                    $stylesFileUrl,
                     [],
                     (string) filemtime($stylesFilePath)
                 );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -63,7 +63,7 @@ class Assets
                     'ecurring_customer_subscriptions',
                     $scriptFileUrl,
                     ['jquery'],
-                    (string) filemtime($scriptFilePath)
+                    (string) filemtime($this->pluginAssetsPath . 'js/customer-subscriptions.js')
                 );
 
                 wp_localize_script(
@@ -80,7 +80,7 @@ class Assets
                     'ecurring_customer_subscriptions',
                     $stylesFileUrl,
                     [],
-                    (string) filemtime($stylesFilePath)
+                    (string) filemtime($this->pluginAssetsPath . 'css/customer-subscriptions.css')
                 );
             }
         );

--- a/woo-ecurring.php
+++ b/woo-ecurring.php
@@ -76,6 +76,11 @@ if ( ! defined( 'WOOECUR_PLUGIN_DIR' ) ) {
 	define( 'WOOECUR_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 }
 
+//Plugin main file
+if (! defined( 'WOOECUR_PLUGIN_FILE' ) ) {
+    define('WOOECUR_PLUGIN_FILE', __FILE__);
+}
+
 /**
  * Called when plugin is loaded
  */


### PR DESCRIPTION
Addresses [ECUR-75](https://inpsyde.atlassian.net/browse/ECUR-75).

Use local asset file path instead of URL to detect last changes with the `filemtime()` function.