### PR TITLE
Notify guests login needed

### DIFF
--- a/.psalm/function-stubs.php
+++ b/.psalm/function-stubs.php
@@ -37,3 +37,8 @@ function _x(string $text, string $context, string $textDomain): string
 {
     return $text;
 }
+
+function wc_get_page_permalink($page, $fallback = null)
+{
+    return '';
+}

--- a/src/EventListener/AddToCartValidationEventListener.php
+++ b/src/EventListener/AddToCartValidationEventListener.php
@@ -83,7 +83,7 @@ class AddToCartValidationEventListener implements EventListenerInterface
     {
         $loginPageLinkOpeningTag = sprintf(
             '<a href="%1$s">',
-            wp_login_url()
+            wc_get_page_permalink('myaccount')
         );
 
         $loginPageLinkClosingTag = '</a>';

--- a/src/EventListener/AddToCartValidationEventListener.php
+++ b/src/EventListener/AddToCartValidationEventListener.php
@@ -100,7 +100,10 @@ class AddToCartValidationEventListener implements EventListenerInterface
         );
 
         wc_add_notice(
-            $loginNeededMessage,
+            sprintf(
+                '<p>%1$s</p>',
+                $loginNeededMessage
+            ),
             'error'
         );
     }

--- a/src/EventListener/AddToCartValidationEventListener.php
+++ b/src/EventListener/AddToCartValidationEventListener.php
@@ -54,6 +54,12 @@ class AddToCartValidationEventListener implements EventListenerInterface
             return $validationPassed;
         }
 
+        if (get_current_user_id() === 0) {
+            $this->addLoginNeededNotice();
+
+            return false;
+        }
+
         if ($quantity > 1 || eCurring_WC_Plugin::eCurringSubscriptionIsInCart()) {
             wc_add_notice(
                 _x(
@@ -68,5 +74,34 @@ class AddToCartValidationEventListener implements EventListenerInterface
         }
 
         return $validationPassed;
+    }
+
+    /**
+     * Add notice for the guest customer about login is requered to buy subscription.
+     */
+    protected function addLoginNeededNotice(): void
+    {
+        $loginPageLinkOpeningTag = sprintf(
+            '<a href="%1$s">',
+            wp_login_url()
+        );
+
+        $loginPageLinkClosingTag = '</a>';
+
+        $loginNeededMessage = sprintf(
+            /* translators: %1$s is replaced with opening html <a> tag, %2$s is replaced with the closing html </a> tag */
+            _x(
+                'Please, %1$slogin or register%2$s first to be able to purchase subscription.',
+                'User notice when guest customer tries to purchase subscription',
+                'woo-ecurring'
+            ),
+            $loginPageLinkOpeningTag,
+            $loginPageLinkClosingTag
+        );
+
+        wc_add_notice(
+            $loginNeededMessage,
+            'error'
+        );
     }
 }

--- a/src/EventListener/AddToCartValidationEventListener.php
+++ b/src/EventListener/AddToCartValidationEventListener.php
@@ -100,10 +100,10 @@ class AddToCartValidationEventListener implements EventListenerInterface
         );
 
         wc_add_notice(
-            sprintf(
+            wp_kses_post(sprintf(
                 '<p>%1$s</p>',
                 $loginNeededMessage
-            ),
+            )),
             'error'
         );
     }

--- a/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
+++ b/src/PaymentGatewaysFilter/PaymentGatewaysFilterInterface.php
@@ -10,7 +10,7 @@ interface PaymentGatewaysFilterInterface
 {
 
     /**
-     * Filter arrays by some criteria.
+     * Filter gateway list by some criteria.
      *
      * @param WC_Payment_Gateway[] $gateways Initial gateways list.
      *

--- a/tests/Unit/AdminPages/AdminControllerTest.php
+++ b/tests/Unit/AdminPages/AdminControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ecurring\WooEcurringTests\AdminPages;
+namespace Ecurring\WooEcurringTests\Unit\AdminPages;
 
 use Brain\Nonces\NonceInterface;
 use ChriCo\Fields\Element\CollectionElementInterface;

--- a/tests/Unit/AdminPages/AdminControllerTest.php
+++ b/tests/Unit/AdminPages/AdminControllerTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Ecurring\WooEcurringTests\AdminPages;
-
 
 use Brain\Nonces\NonceInterface;
 use ChriCo\Fields\Element\CollectionElementInterface;
@@ -15,103 +13,104 @@ use Ecurring\WooEcurring\Settings\SettingsCrudInterface;
 use Ecurring\WooEcurringTests\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+
 use function Brain\Monkey\Functions\when;
 
-class AdminControllerTest extends TestCase {
+class AdminControllerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
 
-	use MockeryPHPUnitIntegration;
+    public function setUp()
+    {
 
-	public function setUp() {
-		$_POST = [];
+        $_POST = [];
 
-		parent::setUp();
-	}
+        parent::setUp();
+    }
 
-	public function testRegisterPluginSettingsTab()
-	{
-		/** @var TemplateInterface&MockObject $adminSettingsPageRendererMock */
-		$adminSettingsPageRendererMock = $this->createMock(TemplateInterface::class);
+    public function testRegisterPluginSettingsTab()
+    {
+        /** @var TemplateInterface&MockObject $adminSettingsPageRendererMock */
+        $adminSettingsPageRendererMock = $this->createMock(TemplateInterface::class);
 
-		/** @var FormFieldsCollectionBuilderInterface&MockObject $formBuilderMock */
-		$formBuilderMock = $this->createMock(FormFieldsCollectionBuilderInterface::class);
+        /** @var FormFieldsCollectionBuilderInterface&MockObject $formBuilderMock */
+        $formBuilderMock = $this->createMock(FormFieldsCollectionBuilderInterface::class);
 
-		/** @var SettingsCrudInterface&MockObject $settingsCrudMock */
-		$settingsCrudMock = $this->createMock(SettingsCrudInterface::class);
+        /** @var SettingsCrudInterface&MockObject $settingsCrudMock */
+        $settingsCrudMock = $this->createMock(SettingsCrudInterface::class);
 
-		/** @var NonceInterface&MockObject $nonceMock */
-		$nonceMock = $this->createMock(NonceInterface::class);
+        /** @var NonceInterface&MockObject $nonceMock */
+        $nonceMock = $this->createMock(NonceInterface::class);
 
-		/** @var NonceFieldBuilderInterface&MockObject $nonceFieldBuilderMock */
-		$nonceFieldBuilderMock = $this->createMock(NonceFieldBuilderInterface::class);
+        /** @var NonceFieldBuilderInterface&MockObject $nonceFieldBuilderMock */
+        $nonceFieldBuilderMock = $this->createMock(NonceFieldBuilderInterface::class);
 
+        $sut = new AdminController(
+            $adminSettingsPageRendererMock,
+            $formBuilderMock,
+            $settingsCrudMock,
+            '',
+            $nonceMock,
+            $nonceFieldBuilderMock
+        );
 
-		$sut = new AdminController(
-			$adminSettingsPageRendererMock,
-			$formBuilderMock,
-			$settingsCrudMock,
-			'',
-			$nonceMock,
-			$nonceFieldBuilderMock
-		);
+        when('_x')->returnArg();
 
-		when('_x')->returnArg();
+        $tabs = [];
 
-		$tabs = [];
+        $tabsWithPluginTab = $sut->registerPluginSettingsTab($tabs);
 
-		$tabsWithPluginTab = $sut->registerPluginSettingsTab($tabs);
+        $this->assertArrayHasKey('mollie_subscriptions', $tabsWithPluginTab);
+    }
 
-		$this->assertArrayHasKey('mollie_subscriptions', $tabsWithPluginTab);
-	}
+    public function testRenderPluginSettingsPage()
+    {
+        /** @var TemplateInterface&MockObject $adminSettingsPageRendererMock */
+        $adminSettingsPageRendererMock = $this->createMock(TemplateInterface::class);
 
-	public function testRenderPluginSettingsPage()
-	{
-		/** @var TemplateInterface&MockObject $adminSettingsPageRendererMock */
-		$adminSettingsPageRendererMock = $this->createMock(TemplateInterface::class);
+        $renderedContent = 'some rendered content';
 
-		$renderedContent = 'some rendered content';
+        $adminSettingsPageRendererMock->expects($this->once())
+            ->method('render')
+            ->willReturn($renderedContent);
 
-		$adminSettingsPageRendererMock->expects($this->once())
-			->method('render')
-			->willReturn($renderedContent);
+        /** @var CollectionElementInterface&MockObject $formFieldsMock */
+        $formFieldsMock = $this->createMock(CollectionElementInterface::class);
 
-		/** @var CollectionElementInterface&MockObject $formFieldsMock */
-		$formFieldsMock = $this->createMock(CollectionElementInterface::class);
+        /** @var RenderableElementInterface&MockObject $formViewMock */
+        $formViewMock = $this->createMock(RenderableElementInterface::class);
 
-		/** @var RenderableElementInterface&MockObject $formViewMock */
-		$formViewMock = $this->createMock(RenderableElementInterface::class);
+        /** @var FormFieldsCollectionBuilderInterface&MockObject $formBuilderMock */
+        $formBuilderMock = $this->createMock(FormFieldsCollectionBuilderInterface::class);
 
-		/** @var FormFieldsCollectionBuilderInterface&MockObject $formBuilderMock */
-		$formBuilderMock = $this->createMock(FormFieldsCollectionBuilderInterface::class);
+        $formBuilderMock->expects($this->once())
+            ->method('buildFieldsCollection')
+            ->willReturn($formFieldsMock);
 
-		$formBuilderMock->expects($this->once())
-			->method('buildFieldsCollection')
-			->willReturn($formFieldsMock);
+        $formBuilderMock->expects($this->once())
+            ->method('buildFormFieldsCollectionView')
+            ->willReturn($formViewMock);
 
-		$formBuilderMock->expects($this->once())
-			->method('buildFormFieldsCollectionView')
-			->willReturn($formViewMock);
+        /** @var SettingsCrudInterface&MockObject $settingsCrudMock */
+        $settingsCrudMock = $this->createMock(SettingsCrudInterface::class);
 
-		/** @var SettingsCrudInterface&MockObject $settingsCrudMock */
-		$settingsCrudMock = $this->createMock(SettingsCrudInterface::class);
+        /** @var NonceInterface&MockObject $nonceMock */
+        $nonceMock = $this->createMock(NonceInterface::class);
 
-		/** @var NonceInterface&MockObject $nonceMock */
-		$nonceMock = $this->createMock(NonceInterface::class);
+        /** @var NonceFieldBuilderInterface&MockObject $nonceFieldBuilderMock */
+        $nonceFieldBuilderMock = $this->createMock(NonceFieldBuilderInterface::class);
 
-		/** @var NonceFieldBuilderInterface&MockObject $nonceFieldBuilderMock */
-		$nonceFieldBuilderMock = $this->createMock(NonceFieldBuilderInterface::class);
+        $sut = new AdminController(
+            $adminSettingsPageRendererMock,
+            $formBuilderMock,
+            $settingsCrudMock,
+            '',
+            $nonceMock,
+            $nonceFieldBuilderMock
+        );
 
-		$sut = new AdminController(
-			$adminSettingsPageRendererMock,
-			$formBuilderMock,
-			$settingsCrudMock,
-			'',
-			$nonceMock,
-			$nonceFieldBuilderMock
-		);
+        $this->expectOutputString($renderedContent);
 
-		$this->expectOutputString($renderedContent);
-
-		$sut->renderPluginSettingsPage();
-
-	}
+        $sut->renderPluginSettingsPage();
+    }
 }

--- a/tests/Unit/AdminPages/Form/FormFieldsCollectionBuilderTest.php
+++ b/tests/Unit/AdminPages/Form/FormFieldsCollectionBuilderTest.php
@@ -1,7 +1,6 @@
 <?php
 
-namespace Ecurring\WooEcurringTests\AdminPages\Form;
-
+namespace Ecurring\WooEcurringTests\Unit\AdminPages\Form;
 
 use ChriCo\Fields\Element\CollectionElementInterface;
 use ChriCo\Fields\ElementFactory;

--- a/tests/Unit/AdminPages/Form/FormFieldsCollectionBuilderTest.php
+++ b/tests/Unit/AdminPages/Form/FormFieldsCollectionBuilderTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Ecurring\WooEcurringTests\AdminPages\Form;
 
 
@@ -12,57 +11,58 @@ use Ecurring\WooEcurring\AdminPages\Form\FormFieldsCollectionBuilder;
 use Ecurring\WooEcurringTests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class FormFieldsCollectionBuilderTest extends TestCase {
+class FormFieldsCollectionBuilderTest extends TestCase
+{
 
-	public function testBuildFieldsCollection()
-	{
-		/** @var CollectionElementInterface&MockObject $elementMock */
-		$elementMock = $this->createMock(CollectionElementInterface::class);
+    public function testBuildFieldsCollection()
+    {
+        /** @var CollectionElementInterface&MockObject $elementMock */
+        $elementMock = $this->createMock(CollectionElementInterface::class);
 
-		/** @var ElementFactory&MockObject $elementFactoryMock */
-		$elementFactoryMock = $this->createMock(ElementFactory::class);
+        /** @var ElementFactory&MockObject $elementFactoryMock */
+        $elementFactoryMock = $this->createMock(ElementFactory::class);
 
-		$elementFactoryMock->expects($this->once())
-			->method('create')
-			->willReturn($elementMock);
+        $elementFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($elementMock);
 
-		/** @var ViewFactory&MockObject $viewFactoryMock */
-		$viewFactoryMock = $this->createMock(ViewFactory::class);
+        /** @var ViewFactory&MockObject $viewFactoryMock */
+        $viewFactoryMock = $this->createMock(ViewFactory::class);
 
-		$formFields = [];
+        $formFields = [];
 
-		$sut = new FormFieldsCollectionBuilder(
-			$elementFactoryMock,
-			$viewFactoryMock,
-			$formFields
-		);
+        $sut = new FormFieldsCollectionBuilder(
+            $elementFactoryMock,
+            $viewFactoryMock,
+            $formFields
+        );
 
-		$this->assertSame($elementMock, $sut->buildFieldsCollection());
-	}
+        $this->assertSame($elementMock, $sut->buildFieldsCollection());
+    }
 
-	public function testBuildFormFieldsCollectionView()
-	{
-		/** @var ElementFactory&MockObject $elementFactoryMock */
-		$elementFactoryMock = $this->createMock(ElementFactory::class);
+    public function testBuildFormFieldsCollectionView()
+    {
+        /** @var ElementFactory&MockObject $elementFactoryMock */
+        $elementFactoryMock = $this->createMock(ElementFactory::class);
 
-		/** @var ViewFactory&MockObject $viewFactoryMock */
-		$viewFactoryMock = $this->createMock(ViewFactory::class);
+        /** @var ViewFactory&MockObject $viewFactoryMock */
+        $viewFactoryMock = $this->createMock(ViewFactory::class);
 
-		$collectionViewMock = $this->createMock(RenderableElementInterface::class);
+        $collectionViewMock = $this->createMock(RenderableElementInterface::class);
 
-		$viewFactoryMock->expects($this->once())
-			->method('create')
-			->with('collection')
-			->willReturn($collectionViewMock);
+        $viewFactoryMock->expects($this->once())
+            ->method('create')
+            ->with('collection')
+            ->willReturn($collectionViewMock);
 
-		$formFields = [];
+        $formFields = [];
 
-		$sut = new FormFieldsCollectionBuilder(
-			$elementFactoryMock,
-			$viewFactoryMock,
-			$formFields
-		);
+        $sut = new FormFieldsCollectionBuilder(
+            $elementFactoryMock,
+            $viewFactoryMock,
+            $formFields
+        );
 
-		$this->assertSame($collectionViewMock, $sut->buildFormFieldsCollectionView());
-	}
+        $this->assertSame($collectionViewMock, $sut->buildFormFieldsCollectionView());
+    }
 }

--- a/tests/Unit/AdminPages/Form/NonceFieldBuilderTest.php
+++ b/tests/Unit/AdminPages/Form/NonceFieldBuilderTest.php
@@ -1,7 +1,6 @@
 <?php
 
-namespace Ecurring\WooEcurringTests\AdminPages\Form;
-
+namespace Ecurring\WooEcurringTests\Unit\AdminPages\Form;
 
 use Brain\Nonces\NonceInterface;
 use ChriCo\Fields\Element\ElementInterface;

--- a/tests/Unit/AdminPages/Form/NonceFieldBuilderTest.php
+++ b/tests/Unit/AdminPages/Form/NonceFieldBuilderTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Ecurring\WooEcurringTests\AdminPages\Form;
 
 
@@ -14,73 +13,70 @@ use Ecurring\WooEcurringTests\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class NonceFieldBuilderTest extends TestCase {
+class NonceFieldBuilderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
 
-	use MockeryPHPUnitIntegration;
+    public function testBuildNonceField()
+    {
+        /** @var ElementFactory&MockObject $elementFactoryMock */
+        $elementFactoryMock = $this->createMock(ElementFactory::class);
 
-	public function testBuildNonceField()
-	{
-		/** @var ElementFactory&MockObject $elementFactoryMock */
-		$elementFactoryMock = $this->createMock(ElementFactory::class);
+        $nonceAction = 'nonceaction';
+        $nonceValue = 'nonce123';
 
-		$nonceAction = 'nonceaction';
-		$nonceValue = 'nonce123';
+        /** @var NonceInterface&MockObject $nonceMock */
+        $nonceMock = $this->createConfiguredMock(
+            NonceInterface::class,
+            [
+                '__toString' => $nonceValue,
+                'action' => $nonceAction,
+            ]
+        );
 
-		/** @var NonceInterface&MockObject $nonceMock */
-		$nonceMock = $this->createConfiguredMock(
-			NonceInterface::class,
-			[
-				'__toString' => $nonceValue,
-				'action' => $nonceAction
-			]
-		);
+        $elementMock = $this->createMock(ElementInterface::class);
 
-		$elementMock = $this->createMock(ElementInterface::class);
+        $elementFactoryMock->expects($this->once())
+           ->method('create')
+           ->with([
+                       'attributes' =>
+                           [
+                               'name' => $nonceAction,
+                               'type' => 'hidden',
+                               'value' => $nonceValue,
+                           ],
+                   ])
+           ->willReturn($elementMock);
 
-		$elementFactoryMock->expects( $this->once() )
-           ->method( 'create' )
-           ->with( [
-	                   'attributes' =>
-		                   [
-			                   'name'  => $nonceAction,
-			                   'type'  => 'hidden',
-			                   'value' => $nonceValue
-		                   ],
-	               ]
-	           )
-           ->willReturn( $elementMock );
+        /** @var ViewFactory&MockObject $viewFactoryMock */
+        $viewFactoryMock = $this->createMock(ViewFactory::class);
 
-		/** @var ViewFactory&MockObject $viewFactoryMock */
-		$viewFactoryMock = $this->createMock(ViewFactory::class);
+        $sut = new NonceFieldBuilder($elementFactoryMock, $viewFactoryMock);
 
-		$sut = new NonceFieldBuilder($elementFactoryMock, $viewFactoryMock);
+        $field = $sut->buildNonceField($nonceMock);
 
-		$field = $sut->buildNonceField($nonceMock);
+        $this->assertInstanceOf(ElementInterface::class, $field);
+    }
 
-		$this->assertInstanceOf(ElementInterface::class, $field);
+    public function testBuildNonceFieldView()
+    {
+        /** @var ElementInterface&MockObject $elementViewMock */
+        $elementViewMock = $this->createMock(RenderableElementInterface::class);
 
-	}
+        /** @var ViewFactory&MockObject $viewFactoryMock */
+        $viewFactoryMock = $this->createMock(ViewFactory::class);
 
+        $viewFactoryMock->expects($this->once())
+            ->method('create')
+            ->with('hidden')
+            ->willReturn($elementViewMock);
 
-	public function testBuildNonceFieldView()
-	{
-		/** @var ElementInterface&MockObject $elementViewMock */
-		$elementViewMock = $this->createMock(RenderableElementInterface::class);
+        /** @var ElementFactory&MockObject $elementFactoryMock */
+        $elementFactoryMock = $this->createMock(ElementFactory::class);
 
-		/** @var ViewFactory&MockObject $viewFactoryMock */
-		$viewFactoryMock = $this->createMock(ViewFactory::class);
+        $sut = new NonceFieldBuilder($elementFactoryMock, $viewFactoryMock);
+        $fieldView = $sut->buildNonceFieldView();
 
-		$viewFactoryMock->expects($this->once())
-			->method('create')
-			->with('hidden')
-			->willReturn($elementViewMock);
-
-		/** @var ElementFactory&MockObject $elementFactoryMock */
-		$elementFactoryMock = $this->createMock(ElementFactory::class);
-
-		$sut = new NonceFieldBuilder($elementFactoryMock, $viewFactoryMock);
-		$fieldView = $sut->buildNonceFieldView();
-
-		$this->assertInstanceOf(RenderableElementInterface::class, $fieldView);
-	}
+        $this->assertInstanceOf(RenderableElementInterface::class, $fieldView);
+    }
 }

--- a/tests/Unit/EnvironmentCheckerTest.php
+++ b/tests/Unit/EnvironmentCheckerTest.php
@@ -8,13 +8,14 @@ use Ecurring\WooEcurring\EnvironmentChecker\EnvironmentChecker;
 use Ecurring\WooEcurringTests\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 use function Patchwork\redefine;
 
-class EnvironmentCheckerTest extends TestCase {
-
-	use MockeryPHPUnitIntegration; //to count Mockery expectations properly as assertions
+class EnvironmentCheckerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration; //to count Mockery expectations properly as assertions
 
     public function testCheckEnvironmentCaseEverythingOk()
     {
@@ -27,7 +28,7 @@ class EnvironmentCheckerTest extends TestCase {
         $versionFactoryMock = $this->createConfiguredMock(
             StringVersionFactoryInterface::class,
             [
-                'createVersionFromString' => $versionMock
+                'createVersionFromString' => $versionMock,
             ]
         );
 
@@ -56,7 +57,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -86,7 +87,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-           ->willReturnCallback(function (string $version){
+           ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version . '.0']
@@ -112,14 +113,13 @@ class EnvironmentCheckerTest extends TestCase {
         $stringFound = false;
 
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'update your PHP')){
+            if (stristr($errorMessage, 'update your PHP')) {
                 $stringFound = true;
                 break;
             }
         }
 
         $this->assertTrue($stringFound, 'Not found expected message about PHP update required.');
-
     }
 
     public function testCheckEnvironmentCaseNoJsonExtension()
@@ -129,7 +129,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version . '.0']
@@ -165,7 +165,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -192,10 +192,8 @@ class EnvironmentCheckerTest extends TestCase {
         $errors = $sut->getErrors();
         $stringFound = false;
 
-
-
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'requires the JSON extension for PHP')){
+            if (stristr($errorMessage, 'requires the JSON extension for PHP')) {
                 $stringFound = true;
                 break;
             }
@@ -211,7 +209,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version . '.0']
@@ -245,7 +243,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -276,7 +274,7 @@ class EnvironmentCheckerTest extends TestCase {
         $stringFound = false;
 
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'install and activate') && stristr($errorMessage, 'WooCommerce')){
+            if (stristr($errorMessage, 'install and activate') && stristr($errorMessage, 'WooCommerce')) {
                 $stringFound = true;
                 break;
             }
@@ -296,7 +294,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version]
@@ -310,7 +308,7 @@ class EnvironmentCheckerTest extends TestCase {
             $versionFactoryMock
         );
 
-        redefine('version_compare', function ($version1) use ($actualPhpVersion) {
+        redefine('version_compare', static function ($version1) use ($actualPhpVersion) {
             //return true for PHP version check, false for WC version check
             return $version1 === $actualPhpVersion;
         });
@@ -335,7 +333,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -359,12 +357,11 @@ class EnvironmentCheckerTest extends TestCase {
 
         $this->assertFalse($sut->checkEnvironment(), 'EnvironmentChecker test false positive.');
 
-
         $errors = $sut->getErrors();
         $stringFound = false;
 
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'update') && stristr($errorMessage, 'WooCommerce')){
+            if (stristr($errorMessage, 'update') && stristr($errorMessage, 'WooCommerce')) {
                 $stringFound = true;
                 break;
             }
@@ -378,7 +375,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version . '.0']
@@ -412,7 +409,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -439,7 +436,7 @@ class EnvironmentCheckerTest extends TestCase {
         $stringFound = false;
 
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'install and activate') && stristr($errorMessage, 'Mollie Payments')){
+            if (stristr($errorMessage, 'install and activate') && stristr($errorMessage, 'Mollie Payments')) {
                 $stringFound = true;
                 break;
             }
@@ -462,7 +459,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 return $this->createConfiguredMock(
                     VersionInterface::class,
                     ['__toString' => $version . '.0']
@@ -496,7 +493,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 
@@ -520,12 +517,11 @@ class EnvironmentCheckerTest extends TestCase {
 
         $this->assertFalse($sut->checkEnvironment(), 'EnvironmentChecker test false positive.');
 
-
         $errors = $sut->getErrors();
         $stringFound = false;
 
         foreach ($errors as $errorMessage) {
-            if(stristr($errorMessage, 'update') && stristr($errorMessage, 'Mollie Payments')){
+            if (stristr($errorMessage, 'update') && stristr($errorMessage, 'Mollie Payments')) {
                 $stringFound = true;
                 break;
             }
@@ -549,7 +545,7 @@ class EnvironmentCheckerTest extends TestCase {
         /** @var StringVersionFactoryInterface&MockObject $versionFactoryMock */
         $versionFactoryMock = $this->createMock(StringVersionFactoryInterface::class);
         $versionFactoryMock->method('createVersionFromString')
-            ->willReturnCallback(function(string $version){
+            ->willReturnCallback(function (string $version) {
                 $normalizedVersion = $version === '6.0' ? '6.0.0' : $version;
                 return $this->createConfiguredMock(
                     VersionInterface::class,
@@ -559,7 +555,6 @@ class EnvironmentCheckerTest extends TestCase {
 
         expect('phpversion')
             ->andReturn($actualPhpVersion);
-
 
         $sut = new EnvironmentChecker(
             $minRequiredPhpVersion,
@@ -588,7 +583,7 @@ class EnvironmentCheckerTest extends TestCase {
         when('esc_html__')
             ->returnArg(1);
 
-        if(! defined('M4W_FILE')){
+        if (! defined('M4W_FILE')) {
             define('M4W_FILE', '');
         }
 

--- a/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
+++ b/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
@@ -117,7 +117,7 @@ class AddToCartValidationEventListenerTest extends TestCase
         $this->assertSame(true, $addedToCart);
     }
 
-    public function testOnAddSubscriptionItsNotAllowedToGuestsToAddSubscription()
+    public function testOnAddSubscriptionGuestsNotAllowedToAddSubscriptionToCart()
     {
         $subscriptionId = '456';
         $productId = 123;

--- a/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
+++ b/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
@@ -34,6 +34,9 @@ class AddToCartValidationEventListenerTest extends TestCase
             ->andReturn($productMock);
         when('_x')->returnArg();
 
+        expect('get_current_user_id')
+            ->andReturn(456);
+
         /** @var SubscriptionCrudInterface&MockObject $subscriptionsCrudMock */
         $subscriptionsCrudMock = $this->createConfiguredMock(
             SubscriptionCrudInterface::class,
@@ -67,6 +70,9 @@ class AddToCartValidationEventListenerTest extends TestCase
             ['getProductSubscriptionId' => $subscriptionId]
         );
 
+        expect('get_current_user_id')
+            ->andReturn(456);
+
         $sut = new AddToCartValidationEventListener($subscriptionsCrudMock);
 
         expect('wc_add_notice')->once();
@@ -97,6 +103,9 @@ class AddToCartValidationEventListenerTest extends TestCase
             SubscriptionCrudInterface::class,
             ['getProductSubscriptionId' => $subscriptionId]
         );
+
+        expect('get_current_user_id')
+            ->andReturn(456);
 
         expect('wc_add_notice')->never();
 

--- a/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
+++ b/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
@@ -146,6 +146,8 @@ class AddToCartValidationEventListenerTest extends TestCase
         when('_x')->returnArg();
         when('wc_get_page_permalink')->justReturn('');
 
+        when('wp_kses_post')->returnArg();
+
         $sut = new AddToCartValidationEventListener($subscriptionsCrudMock);
         $addedToCart = $sut->onAddToCart(true, $productId, 1);
 

--- a/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
+++ b/tests/Unit/EventListener/AddToCartValidationEventListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCurring\WooEcurringTests\Unit\EventListener;
+namespace Ecurring\WooEcurringTests\Unit\EventListener;
 
 use Ecurring\WooEcurring\EventListener\AddToCartValidationEventListener;
 use Ecurring\WooEcurring\Subscription\SubscriptionCrudInterface;

--- a/tests/Unit/EventListener/PaymentCompletedEventListenerTest.php
+++ b/tests/Unit/EventListener/PaymentCompletedEventListenerTest.php
@@ -9,11 +9,10 @@ use Ecurring\WooEcurringTests\TestCase;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+use Ecurring\WooEcurring\EventListener\PaymentCompletedEventListener;
 use WC_Order;
 
 use function Brain\Monkey\Functions\expect;
-
-use Ecurring\WooEcurring\EventListener\PaymentCompletedEventListener;
 use function Brain\Monkey\Functions\when;
 
 class PaymentCompletedEventListenerTest extends TestCase

--- a/tests/Unit/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilterTest.php
+++ b/tests/Unit/PaymentGatewaysFilter/WhitelistedRecurringPaymentGatewaysFilterTest.php
@@ -5,72 +5,73 @@ namespace Ecurring\WooEcurringTests\Unit\PaymentGatewaysFilter;
 use Ecurring\WooEcurring\PaymentGatewaysFilter\WhitelistedRecurringPaymentGatewaysFilter;
 use Ecurring\WooEcurringTests\TestCase;
 use WC_Payment_Gateway;
+
 use function Patchwork\redefine;
 
-class WhitelistedRecurringPaymentGatewaysFilterTest extends TestCase {
+class WhitelistedRecurringPaymentGatewaysFilterTest extends TestCase
+{
 
-	/**
-	 * @dataProvider filterTestDataProvider
-	 */
-	public function testFilter(
-		array $whitelistedClasses,
-		array $gatewaysToFilter,
-		array $expectedResult
-	) {
+    /**
+     * @dataProvider filterTestDataProvider
+     */
+    public function testFilter(
+        array $whitelistedClasses,
+        array $gatewaysToFilter,
+        array $expectedResult
+    ) {
 
-		//Cannot use `expect()` from brain/monkey package because of endless loop is starting after calling `andReturn()`
-		redefine('get_class', function($item){
-			if(! is_object($item)){
-				return false;
-			}
+        //Cannot use `expect()` from brain/monkey package because of endless loop is starting after calling `andReturn()`
+        redefine('get_class', static function ($item) {
+            if (! is_object($item)) {
+                return false;
+            }
 
-			return $item->whitelisted ? 'Some\Whitelisted\Class\Name' : 'Some\Not\Whitelisted\Class\Name';
-		});
+            return $item->whitelisted ? 'Some\Whitelisted\Class\Name' : 'Some\Not\Whitelisted\Class\Name';
+        });
 
-		$sut = new WhitelistedRecurringPaymentGatewaysFilter($whitelistedClasses);
-		$filtered = $sut->filter($gatewaysToFilter);
+        $sut = new WhitelistedRecurringPaymentGatewaysFilter($whitelistedClasses);
+        $filtered = $sut->filter($gatewaysToFilter);
 
-		$this->assertSame($expectedResult, array_values($filtered));
-	}
+        $this->assertSame($expectedResult, array_values($filtered));
+    }
 
-	public function filterTestDataProvider() {
-		$nonRecurringGateway = $this->createMock( WC_Payment_Gateway::class );
-		$nonRecurringGateway->method( 'supports' )
-		                    ->with( 'subscriptions' )
-		                    ->willReturn( false );
+    public function filterTestDataProvider()
+    {
 
-		$nonRecurringGateway->whitelisted = true;
+        $nonRecurringGateway = $this->createMock(WC_Payment_Gateway::class);
+        $nonRecurringGateway->method('supports')
+                            ->with('subscriptions')
+                            ->willReturn(false);
 
+        $nonRecurringGateway->whitelisted = true;
 
-		$recurringGateway = $this->createMock( WC_Payment_Gateway::class );
-		$recurringGateway->method( 'supports' )
-		                 ->with( 'subscriptions' )
-		                 ->willReturn( true );
+        $recurringGateway = $this->createMock(WC_Payment_Gateway::class);
+        $recurringGateway->method('supports')
+                         ->with('subscriptions')
+                         ->willReturn(true);
 
-		$recurringGateway->whitelisted = false;
+        $recurringGateway->whitelisted = false;
 
-		$recurringWhitelistedGateway = $this->createMock( WC_Payment_Gateway::class );
-		$recurringWhitelistedGateway->method( 'supports' )
-		                            ->with( 'subscriptions' )
-		                            ->willReturn( true );
+        $recurringWhitelistedGateway = $this->createMock(WC_Payment_Gateway::class);
+        $recurringWhitelistedGateway->method('supports')
+                                    ->with('subscriptions')
+                                    ->willReturn(true);
 
-		$recurringWhitelistedGateway->whitelisted = true;
+        $recurringWhitelistedGateway->whitelisted = true;
 
+        $whitelist = ['Some\Whitelisted\Class\Name'];
 
-
-		$whitelist = ['Some\Whitelisted\Class\Name'];
-
-		return [
-			[
-				[],
-				[],
-				[]
-			],
-			[
-				$whitelist,
-				[ $nonRecurringGateway, $recurringGateway, $recurringWhitelistedGateway ],
-				[ $recurringWhitelistedGateway ]
-			]
-		];
-	}
+        return [
+            [
+                [],
+                [],
+                [],
+            ],
+            [
+                $whitelist,
+                [ $nonRecurringGateway, $recurringGateway, $recurringWhitelistedGateway ],
+                [ $recurringWhitelistedGateway ],
+            ],
+        ];
+    }
 }

--- a/tests/Unit/Subscription/SubscriptionCrudTest.php
+++ b/tests/Unit/Subscription/SubscriptionCrudTest.php
@@ -6,111 +6,115 @@ use Ecurring\WooEcurring\Subscription\SubscriptionCrud;
 use Ecurring\WooEcurringTests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Order;
+
 use function Brain\Monkey\Functions\when;
 
-class SubscriptionCrudTest extends TestCase {
+class SubscriptionCrudTest extends TestCase
+{
 
-	/**
-	 * @dataProvider subscriptionDataProvider
-	 */
-	public function testSaveSubscription(array $subscriptionData, $subscriptionId)
-	{
-		$mandateAcceptedDate = '2020-01-01';
+    /**
+     * @dataProvider subscriptionDataProvider
+     */
+    public function testSaveSubscription(array $subscriptionData, $subscriptionId)
+    {
+        $mandateAcceptedDate = '2020-01-01';
 
-		/** @var WC_Order&MockObject $wcOrderMock */
-		$wcOrderMock = $this->createMock( WC_Order::class);
+        /** @var WC_Order&MockObject $wcOrderMock */
+        $wcOrderMock = $this->createMock(WC_Order::class);
 
-		$wcOrderMock->expects($this->at(0))
-			->method('update_meta_data')
-			->with(SubscriptionCrud::MANDATE_ACCEPTED_DATE_FIELD, $mandateAcceptedDate);
+        $wcOrderMock->expects($this->at(0))
+            ->method('update_meta_data')
+            ->with(SubscriptionCrud::MANDATE_ACCEPTED_DATE_FIELD, $mandateAcceptedDate);
 
-		$wcOrderMock->expects($this->at(1))
-			->method('update_meta_data')
-			->with(SubscriptionCrud::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
+        $wcOrderMock->expects($this->at(1))
+            ->method('update_meta_data')
+            ->with(SubscriptionCrud::ECURRING_SUBSCRIPTION_ID_FIELD, $subscriptionId);
 
-		$wcOrderMock->expects($this->once())
-			->method('save');
+        $wcOrderMock->expects($this->once())
+            ->method('save');
 
-		when('date')->justReturn($mandateAcceptedDate);
-		when('__')->returnArg();
+        when('date')->justReturn($mandateAcceptedDate);
+        when('__')->returnArg();
 
-		$wcOrderMock->expects($this->once())
-			->method('add_order_note')
-			->with($this->stringContains($subscriptionId));
+        $wcOrderMock->expects($this->once())
+            ->method('add_order_note')
+            ->with($this->stringContains($subscriptionId));
 
-		$sut = new SubscriptionCrud();
-		$sut->saveSubscription($subscriptionData, $wcOrderMock);
-	}
+        $sut = new SubscriptionCrud();
+        $sut->saveSubscription($subscriptionData, $wcOrderMock);
+    }
 
-	/**
-	 * Subscription data example is taken from the eCurring documentation.
-	 *
-	 * @see https://docs.ecurring.com/subscriptions/get
-	 */
-	public function subscriptionDataProvider() {
-		$subscriptionId = '1';
+    /**
+     * Subscription data example is taken from the eCurring documentation.
+     *
+     * @see https://docs.ecurring.com/subscriptions/get
+     */
+    public function subscriptionDataProvider()
+    {
 
-		$mandateAcceptedDate = '2020-01-01';
+        $subscriptionId = '1';
 
-		return [
-			[
-				[
-					"links" => [
-						"self" => "https://api.ecurring.com/subscriptions/1"
-					],
-					"data"  => [
-						"type"          => "subscription",
-						"id"            => $subscriptionId,
-						"links"         => [
-							"self" => "https://api.ecurring.com/subscriptions/1"
-						],
-						"attributes"    => [
-							"mandate_code"             => "ECUR-1",
-							"mandate_accepted"         => true,
-							"mandate_accepted_date"    => $mandateAcceptedDate,
-							"start_date"               => "2017-21-11T22:11:57+01:00",
-							"status"                   => "active",
-							"cancel_date"              => null,
-							"resume_date"              => null,
-							"confirmation_page"        => "https://app.ecurring.com/mandate/accept/1/ECUR-1",
-							"confirmation_sent"        => false,
-							"subscription_webhook_url" => null,
-							"transaction_webhook_url"  => null,
-							"success_redirect_url"     => null,
-							"metadata"                 => [],
-							"archived"                 => false,
-							"created_at"               => "2017-02-01T11:21:09+01:00",
-							"updated_at"               => "2017-02-11T00:00:00+01:00"
-						],
-						"relationships" => [
-							"subscription-plan" => [
-								"data" => [
-									"type" => "subscription-plan",
-									"id"   => "1"
-								]
-							],
-							"customer"          => [
-								"data" => [
-									"type" => "customer",
-									"id"   => "1"
-								]
-							],
-							"transactions"      => [
-								"links" => [
-									"related" => "https://api.ecurring.com/subscriptions/1/transactions"
-								],
-								"data"  => [
-									[
-										"type" => "transaction",
-										"id"   => "02f3c67b-1e1a-4692-8826-14f17f9b2c61"
-									]
-								]
-							]
-						]
-					]
-				],
-				$subscriptionId
-			]
-		];
-	}
+        $mandateAcceptedDate = '2020-01-01';
+
+        return [
+            [
+                [
+                    "links" => [
+                        "self" => "https://api.ecurring.com/subscriptions/1",
+                    ],
+                    "data" => [
+                        "type" => "subscription",
+                        "id" => $subscriptionId,
+                        "links" => [
+                            "self" => "https://api.ecurring.com/subscriptions/1",
+                        ],
+                        "attributes" => [
+                            "mandate_code" => "ECUR-1",
+                            "mandate_accepted" => true,
+                            "mandate_accepted_date" => $mandateAcceptedDate,
+                            "start_date" => "2017-21-11T22:11:57+01:00",
+                            "status" => "active",
+                            "cancel_date" => null,
+                            "resume_date" => null,
+                            "confirmation_page" => "https://app.ecurring.com/mandate/accept/1/ECUR-1",
+                            "confirmation_sent" => false,
+                            "subscription_webhook_url" => null,
+                            "transaction_webhook_url" => null,
+                            "success_redirect_url" => null,
+                            "metadata" => [],
+                            "archived" => false,
+                            "created_at" => "2017-02-01T11:21:09+01:00",
+                            "updated_at" => "2017-02-11T00:00:00+01:00",
+                        ],
+                        "relationships" => [
+                            "subscription-plan" => [
+                                "data" => [
+                                    "type" => "subscription-plan",
+                                    "id" => "1",
+                                ],
+                            ],
+                            "customer" => [
+                                "data" => [
+                                    "type" => "customer",
+                                    "id" => "1",
+                                ],
+                            ],
+                            "transactions" => [
+                                "links" => [
+                                    "related" => "https://api.ecurring.com/subscriptions/1/transactions",
+                                ],
+                                "data" => [
+                                    [
+                                        "type" => "transaction",
+                                        "id" => "02f3c67b-1e1a-4692-8826-14f17f9b2c61",
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                $subscriptionId,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Addresses [ECUR-81](https://inpsyde.atlassian.net/browse/ECUR-81).

Don't let guest customers add a subscription to the cart. After trying to add a message asking to log in to buy subscriptions.

Also, minor fixes:
* method description updated;
* tests code style fixes;
* tests namespaces fixes.

**UPD:** 
1. Woocommerce error message text wrapped in p HTML tag to prevent text from filling all the containing block width.
2. Woocommerce error message text sanitized before outputting.