### PR TITLE
Fix subscription webhook url

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3438,8 +3438,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.6",
-                "reference": "5.6"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.6"
             },
             "require": {
                 "php": ">=5.3.2",
@@ -4267,12 +4266,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7"
+                "reference": "5d9e349571fa1fed2ed89fe1f5ffd58331468e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7",
-                "reference": "021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5d9e349571fa1fed2ed89fe1f5ffd58331468e87",
+                "reference": "5d9e349571fa1fed2ed89fe1f5ffd58331468e87",
                 "shasum": ""
             },
             "require": {
@@ -4353,7 +4352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-20T11:45:16+00:00"
+            "time": "2021-01-23T09:52:46+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5094,12 +5093,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9e0525439d3024e12b3402b2ef7f908ca2cb2e56"
+                "reference": "ae172b2c04f4f2341e09b68a5391baefbccfc905"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9e0525439d3024e12b3402b2ef7f908ca2cb2e56",
-                "reference": "9e0525439d3024e12b3402b2ef7f908ca2cb2e56",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/ae172b2c04f4f2341e09b68a5391baefbccfc905",
+                "reference": "ae172b2c04f4f2341e09b68a5391baefbccfc905",
                 "shasum": ""
             },
             "require": {
@@ -5186,19 +5185,19 @@
                 "inspection",
                 "php"
             ],
-            "time": "2021-01-19T22:22:25+00:00"
+            "time": "2021-01-24T20:00:21+00:00"
         },
         {
             "name": "webmozart/assert",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "9c89b265ccc4092d58e66d72af5d343ee77a41ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/9c89b265ccc4092d58e66d72af5d343ee77a41ae",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9c89b265ccc4092d58e66d72af5d343ee77a41ae",
                 "reference": "9c89b265ccc4092d58e66d72af5d343ee77a41ae",
                 "shasum": ""
             },

--- a/includes/webhook_functions.php
+++ b/includes/webhook_functions.php
@@ -113,7 +113,8 @@ function ecurring_webhook( $request ) {
 				if ($is_first_payment) {
 					$order = wc_get_order( $subscription_order_id );
 
-					update_post_meta( $subscription_order_id, '_transaction_id', $transaction_id );
+					update_post_meta( $subscription_order_id, '_ecurring_transaction_id', $transaction_id );
+					//todo: set _transaction_id from the external_payment_id field from transaction data.
 					$order->update_meta_data( '_first_transaction_completed', '1' );
 
 					$order->add_order_note( sprintf(

--- a/includes/webhook_functions.php
+++ b/includes/webhook_functions.php
@@ -34,8 +34,8 @@ function ecurring_webhook( $request ) {
 			eCurring_WC_Plugin::debug( $transaction );
 
 			// Get related subscription to this transaction
-			$prepare = $wpdb->prepare( "SELECT post_id FROM " . $wpdb->prefix . "postmeta WHERE meta_key = '_ecurring_subscription_id' AND meta_value = '%d'",$subscription_id);
-			$subscription_order_id = $wpdb->get_var( $prepare );
+			$repository = eCurring_WC_Plugin::getSubscriptionRepository();
+			$subscription_order_id = $repository->findSubscriptionOrderIdBySubscriptionId($subscription_id);
 			$subscription_order = wc_get_order( $subscription_order_id );
 
 			if (!$subscription_order) {

--- a/includes/webhook_functions.php
+++ b/includes/webhook_functions.php
@@ -114,7 +114,15 @@ function ecurring_webhook( $request ) {
 					$order = wc_get_order( $subscription_order_id );
 
 					update_post_meta( $subscription_order_id, '_ecurring_transaction_id', $transaction_id );
-					//todo: set _transaction_id from the external_payment_id field from transaction data.
+					$externalPaymentId = '';
+
+					$transactionHistory = $transaction_attrs['history'] ?? [];
+					foreach($transactionHistory as $historyElement){
+					    if(isset($historyElement['status']) && $historyElement['status'] === 'fulfilled'){
+                            $externalPaymentId = (string) $historyElement['external_payment_id'] ?? '';
+                        }
+                    }
+
 					$order->update_meta_data( '_first_transaction_completed', '1' );
 
 					$order->add_order_note( sprintf(
@@ -150,7 +158,7 @@ function ecurring_webhook( $request ) {
 					$payment_method_title = get_post_meta( $subscription_order_id, '_payment_method_title', true );
 
 					// Add meta data to renewal payment
-					update_post_meta($order->get_id(),'_transaction_id',$transaction_id);
+					update_post_meta($order->get_id(),'_transaction_id', $externalPaymentId);
 					update_post_meta($order->get_id(),'_ecurring_transaction_id',$transaction_id);
 					update_post_meta($order->get_id(),'_ecurring_subscription_id',$subscription_id);
 					update_post_meta($order->get_id(),'_payment_method',$payment_method);

--- a/src/Api/Subscriptions.php
+++ b/src/Api/Subscriptions.php
@@ -155,6 +155,8 @@ class Subscriptions
 
         $attributes['customer_id'] = $ecurringCustomerId;
         $attributes['subscription_plan_id'] = $subscriptionPlanId;
+        $attributes['subscription_webhook_url'] = $this->getSubscriptionWebhookUrl();
+        $attributes['transaction_webhook_url'] = $this->getTransactionWebhookUrl();
 
         $requestData = [
             'data' => [
@@ -235,6 +237,34 @@ class Subscriptions
         $normalizedSubscriptionData = $this->normalizeSubscriptionData($response['data']);
 
         return $this->subscriptionFactory->createSubscription($normalizedSubscriptionData);
+    }
+
+    /**
+     * Get the url that should be used by eCurring for subscription webhooks.
+     *
+     * @return string
+     */
+    protected function getSubscriptionWebhookUrl(): string
+    {
+        return add_query_arg(
+            'ecurring-webhook',
+            'subscription',
+            home_url('/')
+        );
+    }
+
+    /**
+     * Get the url that should be used by eCurring for transaction webhooks.
+     *
+     * @return string
+     */
+    protected function getTransactionWebhookUrl(): string
+    {
+        return add_query_arg(
+            'ecurring-webhook',
+            'transaction',
+            home_url('/')
+        );
     }
 
     /**

--- a/src/Subscription/Repository.php
+++ b/src/Subscription/Repository.php
@@ -144,7 +144,7 @@ class Repository
     {
         $subscriptionPostId = $this->findSubscriptionPostIdBySubscriptionId($subscriptionId);
 
-        if ($subscriptionPostId === 0) {
+        if ($subscriptionPostId === '') {
             return null;
         }
 

--- a/src/Subscription/Repository.php
+++ b/src/Subscription/Repository.php
@@ -353,6 +353,10 @@ class Repository
      */
     public function findSubscriptionPostIdBySubscriptionId(string $subscriptionId): int
     {
+        if ($subscriptionId === '') {
+            return 0;
+        }
+        
         /** @var int[] $found */
         $found = get_posts(
             [

--- a/src/Subscription/Repository.php
+++ b/src/Subscription/Repository.php
@@ -144,7 +144,7 @@ class Repository
     {
         $subscriptionPostId = $this->findSubscriptionPostIdBySubscriptionId($subscriptionId);
 
-        if ($subscriptionPostId === '') {
+        if ($subscriptionPostId === 0) {
             return null;
         }
 

--- a/src/Subscription/Repository.php
+++ b/src/Subscription/Repository.php
@@ -356,7 +356,7 @@ class Repository
         if ($subscriptionId === '') {
             return 0;
         }
-        
+
         /** @var int[] $found */
         $found = get_posts(
             [

--- a/src/Subscription/SubscriptionPlanSwitcher/SubscriptionPlanSwitcher.php
+++ b/src/Subscription/SubscriptionPlanSwitcher/SubscriptionPlanSwitcher.php
@@ -106,9 +106,6 @@ class SubscriptionPlanSwitcher implements SubscriptionPlanSwitcherInterface
         $mandate = $oldSubscription->getMandate();
         $mandateAcceptedDate = $mandate->getAcceptedDate();
 
-        $subscriptionWebhookUrl = $this->getSubscriptionWebhookUrl();
-        $transactionWebhookUrl = $this->getTransactionWebhookUrl();
-
         $subscriptionAttributes = [
             'mandate_code' => $mandate->getMandateCode(),
             'mandate_accepted' => true,
@@ -116,8 +113,6 @@ class SubscriptionPlanSwitcher implements SubscriptionPlanSwitcherInterface
                 $mandateAcceptedDate->format('Y-m-d\TH:i:sP') :
                 '',
             'confirmation_sent' => 'true',
-            'subscription_webhook_url' => $subscriptionWebhookUrl,
-            'transaction_webhook_url' => $transactionWebhookUrl,
             'status' => 'active',
             'start_date' => $startDate->format('Y-m-d\TH:i:sP'),
             'metadata' => json_encode($oldSubscription->getMeta()),
@@ -127,30 +122,6 @@ class SubscriptionPlanSwitcher implements SubscriptionPlanSwitcherInterface
             $oldSubscription->getCustomerId(),
             $newSubscriptionPlanId,
             $subscriptionAttributes
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getSubscriptionWebhookUrl(): string
-    {
-        return add_query_arg(
-            'ecurring-webhook',
-            'subscription',
-            home_url('/')
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getTransactionWebhookUrl(): string
-    {
-        return add_query_arg(
-            'ecurring-webhook',
-            'transaction',
-            home_url('/')
         );
     }
 }


### PR DESCRIPTION
Addresses [ECUR-92](https://inpsyde.atlassian.net/browse/ECUR-92) and [ECUR-94](https://inpsyde.atlassian.net/browse/ECUR-94).

Fix adding `subscription_webhook_url` and `transaction_webhook_url` when creating subscriptions so webhooks from the eCurring can be sent. 

Additionally:
* Add methods to get services from outside;
* Set proper order transaction id;
* Save `eCurring` transaction id in the respective field;
* Fix search subscription post id by subscription id.

