### PR TITLE
Rename plugin to WooCommerce eCurring gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ DB_USER_PASSWORD=pass
 DB_PORT = 36033
 
 WP_DOMAIN=woo-ecurring.loc
-WP_TITLE="Mollie subscriptions"
+WP_TITLE="WooCommerce eCurring gateway"
 
 ADMIN_USER=admin
 ADMIN_PASS=admin

--- a/composer.lock
+++ b/composer.lock
@@ -4267,12 +4267,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7"
+                "reference": "5d9e349571fa1fed2ed89fe1f5ffd58331468e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7",
-                "reference": "021965b9ccf6afeaeb906bc0b8c9f1d508aeb4d7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5d9e349571fa1fed2ed89fe1f5ffd58331468e87",
+                "reference": "5d9e349571fa1fed2ed89fe1f5ffd58331468e87",
                 "shasum": ""
             },
             "require": {
@@ -4353,7 +4353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-20T11:45:16+00:00"
+            "time": "2021-01-23T09:52:46+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5094,12 +5094,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9e0525439d3024e12b3402b2ef7f908ca2cb2e56"
+                "reference": "ae172b2c04f4f2341e09b68a5391baefbccfc905"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9e0525439d3024e12b3402b2ef7f908ca2cb2e56",
-                "reference": "9e0525439d3024e12b3402b2ef7f908ca2cb2e56",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/ae172b2c04f4f2341e09b68a5391baefbccfc905",
+                "reference": "ae172b2c04f4f2341e09b68a5391baefbccfc905",
                 "shasum": ""
             },
             "require": {
@@ -5186,19 +5186,19 @@
                 "inspection",
                 "php"
             ],
-            "time": "2021-01-19T22:22:25+00:00"
+            "time": "2021-01-24T20:00:21+00:00"
         },
         {
             "name": "webmozart/assert",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "9c89b265ccc4092d58e66d72af5d343ee77a41ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/9c89b265ccc4092d58e66d72af5d343ee77a41ae",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9c89b265ccc4092d58e66d72af5d343ee77a41ae",
                 "reference": "9c89b265ccc4092d58e66d72af5d343ee77a41ae",
                 "shasum": ""
             },

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Mollie Subscriptions ===
+=== WooCommerce eCurring gateway ===
 Contributors: davdebcom, inpsyde
 Tags: recurring payments, woocommerce, payment gateway, direct debit, subscriptions, woocommerce subscriptions, sepa
 Requires at least: 4.6
@@ -114,7 +114,7 @@ Where possible, also include the eCurring log file. You can find the eCurring lo
 
 = Automatic installation =
 
-1. Install the plugin via Plugins -> New plugin. Search for 'Mollie Subscriptions'.
+1. Install the plugin via Plugins -> New plugin. Search for 'WooCommerce eCurring gateway'.
 2. Activate the 'eCurring for WooCommerce' plugin through the 'Plugins' menu in WordPress
 3. Set your eCurring API key at WooCommerce -> Settings -> Checkout (or use the *eCurring Settings* link in the Plugins overview)
 4. You're done, the active payment methods should be visible in the checkout of your webshop.

--- a/src/AdminPages/AdminController.php
+++ b/src/AdminPages/AdminController.php
@@ -166,7 +166,7 @@ class AdminController
     public function registerPluginSettingsTab(array $tabs): array
     {
         $tabs[self::PLUGIN_SETTINGS_TAB_SLUG] = _x(
-            'Mollie Subscriptions',
+            'WooCommerce eCurring gateway',
             'Plugin settings tab name',
             'woo-ecurring'
         );

--- a/src/AdminPages/ProductEditPageController.php
+++ b/src/AdminPages/ProductEditPageController.php
@@ -76,7 +76,7 @@ class ProductEditPageController
     {
         $productDataTabs['woo-ecurring-tab'] = [
             'label' => _x(
-                'Mollie Subscriptions',
+                'WooCommerce eCurring gateway',
                 'Tab name on the product edit page',
                 'woo-ecurring'
             ),
@@ -158,7 +158,7 @@ class ProductEditPageController
             /* translators: %1$s is replaced with the opening a HTML tag, %2$s is replaced with the closing a tag. */
             _x(
                 'Please, enter an API key on the %1$splugin settings page%2$s to be able to connect subscription to this product.',
-                'Message on the product edit page, Mollie Subscriptions tab',
+                'Message on the product edit page, WooCommerce eCurring gateway tab',
                 'woo-ecurring'
             ),
             $openingTag,

--- a/src/EnvironmentChecker/EnvironmentChecker.php
+++ b/src/EnvironmentChecker/EnvironmentChecker.php
@@ -89,7 +89,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
 
         if (! $phpVersionIsOk) {
             $this->errors[] = __(
-                'Mollie Subscriptions plugin is disabled. Please, update your PHP first.',
+                'WooCommerce eCurring gateway plugin is disabled. Please, update your PHP first.',
                 'woo-ecurring'
             );
         }
@@ -108,7 +108,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
 
         if (! $jsonExtensionLoaded) {
             $this->errors[] = esc_html__(
-                'Mollie Subscriptions requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.',
+                'WooCommerce eCurring gateway plugin requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.',
                 'woo-ecurring'
             );
         }
@@ -134,7 +134,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
                 /* translators: %1$s is replaced with WooCommerce plugin installation page url. */
                 __(
-                    '<strong>Mollie Subscriptions plugin is inactive.</strong> Please, install and activate <a href="%1$s">WooCommerce</a> plugin first.',
+                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, install and activate <a href="%1$s">WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $woocommercePluginPageUrl
@@ -162,7 +162,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
             /* translators: %1$s is replaced with WooCommerce plugin installation page url. */
                 __(
-                    '<strong>Mollie Subscriptions plugin is inactive.</strong> Please, update <a href="%1$s">WooCommerce</a> plugin first.',
+                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, update <a href="%1$s">WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $woocommercePluginPageUrl
@@ -186,7 +186,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
             /* translators: %1$s is replaced with Mollie plugin installation page url. */
                 __(
-                    '<strong>Mollie Subscriptions plugin is inactive.</strong> Please, install and activate <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
+                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, install and activate <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 esc_url($molliePluginPageUrl)
@@ -238,7 +238,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = $mollieIsNotMinimalVersionMessage = sprintf(
             /* translators: %1$s is replaced with Mollie plugin installation page url. */
                 __(
-                    '<strong>Mollie Subscriptions plugin is inactive.</strong> Please, update <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
+                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, update <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $molliePluginPageUrl

--- a/woo-ecurring.php
+++ b/woo-ecurring.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Plugin Name: Mollie Subscriptions
+ * Plugin Name: WooCommerce eCurring gateway
  * Plugin URI: https://www.ecurring.com/
  * Description: Collect your subscription fees in WooCommerce with ease.
  * Version: 1.2.0


### PR DESCRIPTION
Addresses [ECUR-93](https://inpsyde.atlassian.net/browse/ECUR-93).

Change plugin name in the main file (displayed in the WP plugins list), readme files, and in user notices.