### PR TITLE
Rename plugin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooCommerce eCurring gateway ===
+=== eCurring Gateway for WooCommerce ===
 Contributors: davdebcom, inpsyde
 Tags: recurring payments, woocommerce, payment gateway, direct debit, subscriptions, woocommerce subscriptions, sepa
 Requires at least: 4.6
@@ -114,7 +114,7 @@ Where possible, also include the eCurring log file. You can find the eCurring lo
 
 = Automatic installation =
 
-1. Install the plugin via Plugins -> New plugin. Search for 'WooCommerce eCurring gateway'.
+1. Install the plugin via Plugins -> New plugin. Search for 'eCurring Gateway for WooCommerce'.
 2. Activate the 'eCurring for WooCommerce' plugin through the 'Plugins' menu in WordPress
 3. Set your eCurring API key at WooCommerce -> Settings -> Checkout (or use the *eCurring Settings* link in the Plugins overview)
 4. You're done, the active payment methods should be visible in the checkout of your webshop.

--- a/src/AdminPages/AdminController.php
+++ b/src/AdminPages/AdminController.php
@@ -166,7 +166,7 @@ class AdminController
     public function registerPluginSettingsTab(array $tabs): array
     {
         $tabs[self::PLUGIN_SETTINGS_TAB_SLUG] = _x(
-            'WooCommerce eCurring gateway',
+            'eCurring Gateway for WooCommerce',
             'Plugin settings tab name',
             'woo-ecurring'
         );

--- a/src/AdminPages/ProductEditPageController.php
+++ b/src/AdminPages/ProductEditPageController.php
@@ -76,7 +76,7 @@ class ProductEditPageController
     {
         $productDataTabs['woo-ecurring-tab'] = [
             'label' => _x(
-                'WooCommerce eCurring gateway',
+                'eCurring Gateway for WooCommerce',
                 'Tab name on the product edit page',
                 'woo-ecurring'
             ),
@@ -158,7 +158,7 @@ class ProductEditPageController
             /* translators: %1$s is replaced with the opening a HTML tag, %2$s is replaced with the closing a tag. */
             _x(
                 'Please, enter an API key on the %1$splugin settings page%2$s to be able to connect subscription to this product.',
-                'Message on the product edit page, WooCommerce eCurring gateway tab',
+                'Message on the product edit page, eCurring Gateway for WooCommerce tab',
                 'woo-ecurring'
             ),
             $openingTag,

--- a/src/EnvironmentChecker/EnvironmentChecker.php
+++ b/src/EnvironmentChecker/EnvironmentChecker.php
@@ -89,7 +89,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
 
         if (! $phpVersionIsOk) {
             $this->errors[] = __(
-                'WooCommerce eCurring gateway plugin is disabled. Please, update your PHP first.',
+                'eCurring Gateway for WooCommerce plugin is disabled. Please, update your PHP first.',
                 'woo-ecurring'
             );
         }
@@ -108,7 +108,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
 
         if (! $jsonExtensionLoaded) {
             $this->errors[] = esc_html__(
-                'WooCommerce eCurring gateway plugin requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.',
+                'eCurring Gateway for WooCommerce plugin requires the JSON extension for PHP. Enable it in your server or ask your webhoster to enable it for you.',
                 'woo-ecurring'
             );
         }
@@ -134,7 +134,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
                 /* translators: %1$s is replaced with WooCommerce plugin installation page url. */
                 __(
-                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, install and activate <a href="%1$s">WooCommerce</a> plugin first.',
+                    '<strong>eCurring Gateway for WooCommerce plugin is inactive.</strong> Please, install and activate <a href="%1$s">WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $woocommercePluginPageUrl
@@ -162,7 +162,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
             /* translators: %1$s is replaced with WooCommerce plugin installation page url. */
                 __(
-                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, update <a href="%1$s">WooCommerce</a> plugin first.',
+                    '<strong>eCurring Gateway for WooCommerce plugin is inactive.</strong> Please, update <a href="%1$s">WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $woocommercePluginPageUrl
@@ -186,7 +186,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = sprintf(
             /* translators: %1$s is replaced with Mollie plugin installation page url. */
                 __(
-                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, install and activate <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
+                    '<strong>eCurring Gateway for WooCommerce plugin is inactive.</strong> Please, install and activate <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 esc_url($molliePluginPageUrl)
@@ -238,7 +238,7 @@ class EnvironmentChecker implements EnvironmentCheckerInterface
             $this->errors[] = $mollieIsNotMinimalVersionMessage = sprintf(
             /* translators: %1$s is replaced with Mollie plugin installation page url. */
                 __(
-                    '<strong>WooCommerce eCurring gateway plugin is inactive.</strong> Please, update <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
+                    '<strong>eCurring Gateway for WooCommerce plugin is inactive.</strong> Please, update <a href="%1$s">Mollie Payments for WooCommerce</a> plugin first.',
                     'woo-ecurring'
                 ),
                 $molliePluginPageUrl

--- a/woo-ecurring.php
+++ b/woo-ecurring.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Plugin Name: WooCommerce eCurring gateway
+ * Plugin Name: eCurring Gateway for WooCommerce
  * Plugin URI: https://www.ecurring.com/
  * Description: Collect your subscription fees in WooCommerce with ease.
  * Version: 1.2.0


### PR DESCRIPTION
Addresses [ECUR-102](https://inpsyde.atlassian.net/browse/ECUR-102).

Change plugin name from "WooCommerce eCurring gateway" to "eCurring Gateway for WooCommerce".