### PR TITLE
Fix wrong UI text

### DIFF
--- a/src/Customer/Subscriptions.php
+++ b/src/Customer/Subscriptions.php
@@ -225,7 +225,7 @@ class Subscriptions
                                          data-subscription="<?php echo esc_attr($subscription->getId()); ?>">
                                         <label><input name="ecurring_pause_subscription"
                                                       type="radio"
-                                                      value="infinite"
+                                                      value="immediately"
                                                       class="tog"
                                                       checked="checked"
                                             /><?php
@@ -311,7 +311,8 @@ class Subscriptions
                                          data-subscription="<?php echo esc_attr($subscription->getId()); ?>">
                                         <label><input name="ecurring_cancel_subscription"
                                                       type="radio"
-                                                      value="infinite" class="tog"
+                                                      value="immediately"
+                                                      class="tog"
                                                       checked="checked"
                                             /><?php
                                                 echo esc_html_x(

--- a/src/Customer/Subscriptions.php
+++ b/src/Customer/Subscriptions.php
@@ -230,7 +230,7 @@ class Subscriptions
                                                       checked="checked"
                                             /><?php
                                                 echo esc_html_x(
-                                                    'Infinite',
+                                                    'Immediately',
                                                     'Label on the Subscriptions page in my account',
                                                     'woo-ecurring'
                                                 ); ?>
@@ -315,7 +315,7 @@ class Subscriptions
                                                       checked="checked"
                                             /><?php
                                                 echo esc_html_x(
-                                                    'Infinite',
+                                                    'Immediately',
                                                     'Label on the Subscriptions page in my account',
                                                     'woo-ecurring'
                                                 ); ?></label>

--- a/src/Subscription/Metabox/Display.php
+++ b/src/Subscription/Metabox/Display.php
@@ -182,7 +182,7 @@ class Display
                           class="tog"
                           checked="checked"/><?php
                                                     echo esc_html_x(
-                                                        'Infinite',
+                                                        'Immediately',
                                                         'Admin meta box context',
                                                         'woo-ecurring'
                                                     );?></label>
@@ -286,7 +286,7 @@ class Display
                         value="infinite"
                         class="tog"
                         checked="checked"
-                /><?php esc_html_x('Infinite', 'Admin meta box content', 'woo-ecurring');?></label>
+                /><?php esc_html_x('Immediately', 'Admin meta box content', 'woo-ecurring');?></label>
             <label><input name="ecurring_cancel_subscription" type="radio" value="specific-date"
                           class="tog"/><?php esc_html_x('Specific date', 'Admin meta box content', 'woo-ecurring'); ?></label>
             <input name="ecurring_cancel_date" type="date"

--- a/src/Subscription/Metabox/Display.php
+++ b/src/Subscription/Metabox/Display.php
@@ -178,7 +178,7 @@ class Display
                     'Admin meta box content',
                     'woo-ecurring'
                 ); ?></h4>
-            <label><input name="ecurring_pause_subscription" type="radio" value="infinite"
+            <label><input name="ecurring_pause_subscription" type="radio" value="immediately"
                           class="tog"
                           checked="checked"/><?php
                                                     echo esc_html_x(
@@ -283,7 +283,7 @@ class Display
             <label><input
                         name="ecurring_cancel_subscription"
                         type="radio"
-                        value="infinite"
+                        value="immediately"
                         class="tog"
                         checked="checked"
                 /><?php esc_html_x('Immediately', 'Admin meta box content', 'woo-ecurring');?></label>


### PR DESCRIPTION
Addresses [ECUR-104](https://inpsyde.atlassian.net/browse/ECUR-104).
Replace 'Infinite' with 'Immediately' as a pause subscription option label text. Also, replace 'infinite' with 'immediately' in the option value for consistency. This doesn't affect any behavior.

Depends on https://github.com/ecurring/woocommerce/pull/58.